### PR TITLE
Fails to load on Rails 2.x

### DIFF
--- a/lib/dotenv.rb
+++ b/lib/dotenv.rb
@@ -6,4 +6,4 @@ module Dotenv
   end
 end
 
-require 'dotenv/railtie' if defined?(Rails)
+require 'dotenv/railtie' if defined?(Rails) and defined?(Rails::Railtie)


### PR DESCRIPTION
```
`load_missing_constant':NameError: uninitialized constant Rails::Railtie
```

Should be easy to check for Rails::Railtie before loading the railtie here: https://github.com/bkeepers/dotenv/blob/master/lib/dotenv.rb#L9
