### PR TITLE
Fixes for Rake::DSL deprecation warnings

### DIFF
--- a/lib/dotenv/railtie.rb
+++ b/lib/dotenv/railtie.rb
@@ -1,4 +1,5 @@
-include Rake::DSL
+include Rake::DSL if defined? Rake
+
 module Dotenv
   class Railtie < Rails::Railtie
     rake_tasks do


### PR DESCRIPTION
Including the `Rake::DSL` module in `/lib/dotenv/railtie.rb` when required (when `Rake` is already loaded) in order to surpress the deprecation warnings thrown when running rake tasks.

```
ruby 1.9.3p286 (2012-10-12 revision 37165) [x86_64-linux]
Rails 3.1.3
```

Before the patch, running a rake task was throwing the following warnings:

```
WARNING: Global access to Rake DSL methods is deprecated.  Please include
    ...  Rake::DSL into classes and modules which use the Rake DSL methods.
WARNING: DSL method Class#desc called at /usr/local/rvm/gems/ruby-1.9.3-p286/gems/dotenv-0.3.0/lib/dotenv/railtie.rb:4:in `block in <class:Railtie>'
WARNING: DSL method Class#task called at /usr/local/rvm/gems/ruby-1.9.3-p286/gems/dotenv-0.3.0/lib/dotenv/railtie.rb:5:in `block in <class:Railtie>'
WARNING: DSL method Class#task called at /usr/local/rvm/gems/ruby-1.9.3-p286/gems/dotenv-0.3.0/lib/dotenv/railtie.rb:9:in `block in <class:Railtie>'
```
