### PR TITLE
Add support for quoted options

### DIFF
--- a/lib/dotenv/environment.rb
+++ b/lib/dotenv/environment.rb
@@ -7,7 +7,7 @@ module Dotenv
 
     def load
       read.each do |line|
-        self[$1] = $2 if line =~ /\A([\w_]+)=(.*)\z/
+        self[$1] = $3 || $4 if line =~ /\A([\w_]+)=('([^']*)'|([^']*))\z/
       end
     end
 

--- a/spec/dotenv_spec.rb
+++ b/spec/dotenv_spec.rb
@@ -39,6 +39,18 @@ describe Dotenv do
       it 'returns hash of loaded environments' do
         expect(subject).to eq(expected)
       end
+
+      context 'with quoted file' do
+        let(:expected) do
+          {'OPTION_A' => '1', 'OPTION_B' => '2', 'OPTION_C' => '', 'OPTION_D' => '\n', 'DOTENV' => 'true'}
+        end
+        let(:env_path) { fixture_path('quoted.env') }
+
+        it 'returns hash of loaded environments' do
+          expect(subject).to eq(expected)
+        end
+
+      end
     end
   end
 

--- a/spec/fixtures/quoted.env
+++ b/spec/fixtures/quoted.env
@@ -1,0 +1,4 @@
+OPTION_A='1'
+OPTION_B='2'
+OPTION_C=''
+OPTION_D='\n'


### PR DESCRIPTION
Foreman accepts this kind of format:

```
OPTION_A='value'
```

This PR adds this functionality....

and: thx for this great gem!
