### PR TITLE
Load the environment on require in Rails

### DIFF
--- a/lib/dotenv/railtie.rb
+++ b/lib/dotenv/railtie.rb
@@ -7,12 +7,8 @@ module Dotenv
       task :dotenv do
         Dotenv.load ".env.#{Rails.env}", '.env'
       end
-
-      task :environment => :dotenv
-    end
-
-    before_configuration 'dotenv', :group => :all do
-      Dotenv.load ".env.#{Rails.env}", '.env'
     end
   end
 end
+
+Dotenv.load ".env.#{Rails.env}", '.env'


### PR DESCRIPTION
This addresses #10 by immediately loading environment variables when `dotenv` is required in Rails. I don't love this solution, but it works.
