### PR TITLE
Fix initializer usage to run as soon as possible

### DIFF
--- a/lib/dotenv/railtie.rb
+++ b/lib/dotenv/railtie.rb
@@ -11,7 +11,7 @@ module Dotenv
       task :environment => :dotenv
     end
 
-    before_configuration 'dotenv', :group => :all do
+    initializer 'dotenv', before: :load_environment_config do
       Dotenv.load ".env.#{Rails.env}", '.env'
     end
   end


### PR DESCRIPTION
Following up from my comment here: https://github.com/bkeepers/dotenv/commit/b9f2810556d8b9daf1514895f59fdba2bdd67116

Would be interested to hear if you had any thoughts on a different place to put it in the long chain of slots you can slip it into, but this seems to work fine and my understanding of the problem this gem strives to solve is that sooner is better.

Apologies if I missed something, but I couldn't find anything on the `before_configuration` method you were trying to use, maybe it might work as `config.before_configuration`? I think using `initializer` is more standard though.
