### PR TITLE
Simplify a regular expression

### DIFF
--- a/lib/dotenv/environment.rb
+++ b/lib/dotenv/environment.rb
@@ -7,7 +7,7 @@ module Dotenv
 
     def load
       read.each do |line|
-        self[$1] = $2 || $3 if line =~ /\A([\w_]+)(?:=|: ?)(?:'([^']*)'|([^']*))\z/
+        self[$1] = $2 || $3 if line =~ /\A(\w+)(?:=|: ?)(?:'([^']*)'|([^']*))\z/
       end
     end
 


### PR DESCRIPTION
The regex literal "\w" matches "_" .
This commit removes a ruby's warning "character class has duplicated range".
