### PR TITLE
Allow `export ` before variables in .env

### DIFF
--- a/lib/dotenv/environment.rb
+++ b/lib/dotenv/environment.rb
@@ -7,7 +7,7 @@ module Dotenv
 
     def load
       read.each do |line|
-        self[$1] = $2 || $3 if line =~ /\A(\w+)(?:=|: ?)(?:['"]([^'"]*)['"]|([^'"]*))\z/
+        self[$1] = $2 || $3 if line =~ /\A(?:export\s+)?(\w+)(?:=|: ?)(?:['"]([^'"]*)['"]|([^'"]*))\z/
       end
     end
 


### PR DESCRIPTION
This change allows .env to be used by both dotenv and processes
like Pow, which requires variables to be exported.
