### PR TITLE
add Dotenv.load!

### DIFF
--- a/lib/dotenv.rb
+++ b/lib/dotenv.rb
@@ -2,11 +2,23 @@ require 'dotenv/environment'
 
 module Dotenv
   def self.load(*filenames)
-    filenames << '.env' if filenames.empty?
-    filenames.inject({}) do |hash, filename|
-      hash.update Environment.new(filename).apply if File.exists?(filename)
-      hash
+    default_if_empty(filenames).inject({}) do |hash, filename|
+      hash.merge(File.exists?(filename) ? Environment.new(filename).apply : {})
     end
+  end
+
+  # same as `load`, but raises Errno::ENOENT if any files don't exist
+  def self.load!(*filenames)
+    load(
+      *default_if_empty(filenames).each do |filename|
+        raise(Errno::ENOENT.new(filename)) unless File.exists?(filename)
+      end
+    )
+  end
+
+protected
+  def self.default_if_empty(filenames)
+    filenames.empty? ? (filenames << '.env') : filenames
   end
 end
 

--- a/spec/dotenv_spec.rb
+++ b/spec/dotenv_spec.rb
@@ -44,6 +44,22 @@ describe Dotenv do
 
   end
 
+  describe 'load!' do
+    context 'with multiple files' do
+      context 'when one file exists and one does not' do
+        subject { Dotenv.load!('.env', '.env_does_not_exist') }
+
+        it 'raises an Errno::ENOENT error and does not load any files' do
+          expect do
+            expect do
+              subject
+            end.to raise_error(Errno::ENOENT)
+          end.to_not change { ENV.keys }
+        end
+      end
+    end
+  end
+
   def fixture_path(name)
     File.join(File.expand_path('../fixtures', __FILE__), name)
   end


### PR DESCRIPTION
`Dotenv.load!` is exactly the same as `Dotenv.load` except it fails fast and hard by raising an instance of `Errno::ENOENT` if any of the filename arguments don't exist.

This changeset also includes some small refactoring to dotenv.rb since there was shared functionality between the two methods (DRY and all that).
