### PR TITLE
Ensure Rake::DSL is truly available

### DIFF
--- a/lib/dotenv/railtie.rb
+++ b/lib/dotenv/railtie.rb
@@ -2,7 +2,7 @@ require 'dotenv'
 
 module Dotenv
   class Railtie < Rails::Railtie
-    include Rake::DSL if defined?(Rake)
+    include Rake::DSL if defined?(Rake) && defined?(Rake::DSL)
 
     rake_tasks do
       desc 'Load environment settings from .env'


### PR DESCRIPTION
The TeamCity CI server runs Rspec tests in an unusual environment. I haven't gotten to the bottom of it, but it somehow creates a Rake class (or constant) but Rake::DSL isn't available. This fails all tests with the following:

```
.../dotenv-0.7.0/lib/dotenv/railtie.rb:5:in `<class:Railtie>': uninitialized constant Rake::DSL (NameError)
```
