### PR TITLE
Add ability to parse '.' in variable names.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .yardoc
 Gemfile.lock
 tmp
+vendor

--- a/lib/dotenv/environment.rb
+++ b/lib/dotenv/environment.rb
@@ -7,7 +7,7 @@ module Dotenv
 
     def load
       read.each do |line|
-        if line =~ /\A(?:export\s+)?(\w+)(?:=|: ?)(.*)\z/
+        if line =~ /\A(?:export\s+)?([\w\.]+)(?:=|: ?)(.*)\z/
           key = $1
           case val = $2
           # Remove single quotes

--- a/spec/dotenv/environment_spec.rb
+++ b/spec/dotenv/environment_spec.rb
@@ -57,6 +57,10 @@ describe Dotenv::Environment do
     expect(env('FOO="bar\nbaz"')).to eql({"FOO" => "bar\nbaz"})
   end
 
+  it 'parses varibales with "." in the name' do
+    expect(env('FOO.BAR=foobar')).to eql({"FOO.BAR" => "foobar"})
+  end
+
   require 'tempfile'
   def env(text)
     file = Tempfile.new('dotenv')


### PR DESCRIPTION
Variables with `.` in them will now be parsed.

``` shell
FOO.BAR=foobar
```
