### PR TITLE
Override predefined variables

### DIFF
--- a/lib/dotenv/environment.rb
+++ b/lib/dotenv/environment.rb
@@ -41,7 +41,7 @@ module Dotenv
     end
 
     def apply
-      each { |k,v| ENV[k] ||= v }
+      each { |k,v| ENV[k] = v }
     end
   end
 end

--- a/spec/dotenv/environment_spec.rb
+++ b/spec/dotenv/environment_spec.rb
@@ -22,10 +22,10 @@ describe Dotenv::Environment do
       expect(ENV['OPTION_A']).to eq('1')
     end
 
-    it 'does not override defined variables' do
+    it 'does override defined variables' do
       ENV['OPTION_A'] = 'predefined'
       subject.apply
-      expect(ENV['OPTION_A']).to eq('predefined')
+      expect(ENV['OPTION_A']).to eq('1')
     end
   end
 


### PR DESCRIPTION
ie. so changing values in `.env` actually works

The problems we're trying to solve with dotenv:
- we want settings from environment variables to come in to our app [PASS] 
- we're using unicorn and restarting (with zero downtime), but we need our
  environment variables to be override-able in each new fork  [FAIL - the values
  are inherited from their parernt]

Which is why we need to change the current behaviour of dotenv to override predefined variables.
(Perhaps there is a way of configuring the gem to have either behaviour?)
