### PR TITLE
Add /etc/environment to rails dotenv files

### DIFF
--- a/lib/dotenv/railtie.rb
+++ b/lib/dotenv/railtie.rb
@@ -1,14 +1,16 @@
 require 'dotenv'
 
+DOTENV_FILES=[".env.#{Rails.env}", '.env', '/etc/environment']
+
 module Dotenv
   class Railtie < Rails::Railtie
     rake_tasks do
       desc 'Load environment settings from .env'
       task :dotenv do
-        Dotenv.load ".env.#{Rails.env}", '.env'
+        Dotenv.load *DOTENV_FILES
       end
     end
   end
 end
 
-Dotenv.load ".env.#{Rails.env}", '.env'
+Dotenv.load *DOTENV_FILES


### PR DESCRIPTION
Add `/etc/environment` to the list of possible locations for the `.env` file.
