### PR TITLE
Ability to control overriding existing ENV vars

### DIFF
--- a/lib/dotenv.rb
+++ b/lib/dotenv.rb
@@ -1,6 +1,12 @@
 require 'dotenv/environment'
 
 module Dotenv
+  @@override ||= false
+  
+  def self.override?
+    @@override
+  end
+
   def self.load(*filenames)
     default_if_empty(filenames).inject({}) do |hash, filename|
       filename = File.expand_path filename

--- a/lib/dotenv/environment.rb
+++ b/lib/dotenv/environment.rb
@@ -41,7 +41,9 @@ module Dotenv
     end
 
     def apply
-      each { |k,v| ENV[k] ||= v }
+      each do |k,v|
+        ENV[k] = v if Dotenv.override? || !ENV.has_key?(k)
+      end
     end
   end
 end

--- a/lib/dotenv/railtie.rb
+++ b/lib/dotenv/railtie.rb
@@ -5,10 +5,12 @@ module Dotenv
     rake_tasks do
       desc 'Load environment settings from .env'
       task :dotenv do
-        Dotenv.load ".env.#{Rails.env}", '.env'
+        filenames = [".env.#{Rails.env}", '.env']
+        Dotenv.load *(Dotenv.override? ? filenames.reverse : filenames)
       end
     end
   end
 end
 
-Dotenv.load ".env.#{Rails.env}", '.env'
+filenames = [".env.#{Rails.env}", '.env']
+Dotenv.load *(Dotenv.override? ? filenames.reverse : filenames)

--- a/lib/override.rb
+++ b/lib/override.rb
@@ -1,0 +1,5 @@
+module Dotenv
+  @@override = true
+end
+
+require (defined?(Rails) ? 'dotenv-rails' : 'dotenv')

--- a/spec/dotenv/environment_spec.rb
+++ b/spec/dotenv/environment_spec.rb
@@ -21,11 +21,23 @@ describe Dotenv::Environment do
       subject.apply
       expect(ENV['OPTION_A']).to eq('1')
     end
+    
+    context 'when not set to override defined variables' do
+      it 'does not override defined variables' do
+        ENV['OPTION_A'] = 'predefined'
+        subject.apply
+        expect(ENV['OPTION_A']).to eq('predefined')
+      end
+    end
 
-    it 'does not override defined variables' do
-      ENV['OPTION_A'] = 'predefined'
-      subject.apply
-      expect(ENV['OPTION_A']).to eq('predefined')
+    context 'when set to override defined variables' do
+      before(:all) { Dotenv.class_variable_set :@@override, true }
+      after(:all) { Dotenv.class_variable_set :@@override, false }
+      it 'does override defined variables' do
+        ENV['OPTION_A'] = 'predefined'
+        subject.apply
+        expect(ENV['OPTION_A']).to eq('1')
+      end
     end
   end
 

--- a/spec/dotenv_spec.rb
+++ b/spec/dotenv_spec.rb
@@ -82,6 +82,13 @@ describe Dotenv do
     end
   end
 
+  describe 'override?' do
+    it 'returns the value of the @@override class variable' do
+      Dotenv.class_variable_set :@@override, true
+      expect(Dotenv.override?).to eq(true)
+    end
+  end
+
   def fixture_path(name)
     File.join(File.expand_path('../fixtures', __FILE__), name)
   end


### PR DESCRIPTION
This is a first shot at using a custom gem require to allow configuring whether dotenv will override ENV vars if they're already set.

It's a bit of an awkward solution, but given the fact that something like this needs to be configured before dotenv is loaded, this seems like the best approach.

If being used in rails (`Rails` is defined), then `dotenv-rails` is required, otherwise `dotenv` - if there are any problems with this, maybe we can rethink that piece. Alternately, perhaps checking for rails in the core `dotenv` lib could eliminate the need for `dotenv-rails` altogether?

The railtie has been updated to reverse the order of the env files in the case where overriding is enabled to ensure the same end results.

If you'd like to use something other than a class variable, or would like to abstract this to a config object of some sort, that can be done pretty easily.

This was in reference to https://github.com/bkeepers/dotenv/pull/38 and some of the original thinking behind it is in the comments there. This is just an idea of one way to approach the feature, so of course feel free to reject the PR if you're not fond of this solution!
