### PR TITLE
Remember loaded variables for later inquiry

### DIFF
--- a/lib/dotenv.rb
+++ b/lib/dotenv.rb
@@ -4,7 +4,7 @@ module Dotenv
   def self.load(*filenames)
     default_if_empty(filenames).inject({}) do |hash, filename|
       filename = File.expand_path filename
-      hash.merge(File.exists?(filename) ? Environment.new(filename).apply : {})
+      @loaded = hash.merge(File.exists?(filename) ? Environment.new(filename).apply : {})
     end
   end
 
@@ -16,6 +16,10 @@ module Dotenv
         raise(Errno::ENOENT.new(filename)) unless File.exists?(filename)
       end
     )
+  end
+
+  def self.loaded
+    @loaded ||= {}
   end
 
 protected

--- a/spec/dotenv_spec.rb
+++ b/spec/dotenv_spec.rb
@@ -62,6 +62,18 @@ describe Dotenv do
         expect(ENV.keys).to eq(@env_keys)
       end
     end
+
+    context 'when the file does exist' do
+      let(:env_files) { [fixture_path('plain.env')] }
+
+      it 'remembers loaded variables' do
+        prev_env = ENV.to_hash
+        subject
+        added = ENV.to_hash.reject { |key, value| value == prev_env[key] }
+
+        expect(Dotenv.loaded).to eq(added)
+      end
+    end
   end
 
   describe 'load!' do


### PR DESCRIPTION
Provide a Dotenv.loaded hash for convenience.

Example use case:

When running my project's test suite, I want to loop through all variables in .env,
and exclude them from VCR 'cassettes' with VCR's filter_sensitive_data method.
By looping through through Dotenv.loaded.keys, I can configure this once, and no
longer have to worry about environment-specific values polluting my test fixtures.

Any reactions or feedback on this idea?