### PR TITLE
Support overriding defined variables

### DIFF
--- a/lib/dotenv/environment.rb
+++ b/lib/dotenv/environment.rb
@@ -70,7 +70,11 @@ module Dotenv
     end
 
     def apply
-      each { |k,v| ENV[k] ||= v }
+      if self.key?('DOTENV_OVERRIDE') && self['DOTENV_OVERRIDE']=="yes"
+        each { |k,v| ENV[k] = v }
+      else
+        each { |k,v| ENV[k] ||= v }
+      end
     end
   end
 end

--- a/spec/dotenv/environment_spec.rb
+++ b/spec/dotenv/environment_spec.rb
@@ -27,6 +27,14 @@ describe Dotenv::Environment do
       subject.apply
       expect(ENV['OPTION_A']).to eq('predefined')
     end
+    
+    it 'overrides defined variables when DOTENV_OVERRIDE==yes' do
+      subject = env("OPTION_A=1\nOPTION_B=2\nDOTENV_OVERRIDE=yes")
+      ENV['OPTION_A'] = 'predefined'
+      ENV['DOTENV_OVERRIDE'] = 'yes'
+      subject.apply
+      expect(ENV['OPTION_A']).to eq('1')
+    end
   end
 
   it 'parses unquoted values' do


### PR DESCRIPTION
Supports overriding variables when DOTENV_OVERRIDE==yes (loaded from env). This setting must come from the first file loaded to apply to everything loaded, eg. if there is only .env then it'll just work but if theres both .env and .env.production for example, the setting must be in .env.production. I guess, with the right eyes, it's a feature.
