### PR TITLE
Add dotenv_role config variable

### DIFF
--- a/lib/dotenv/capistrano/recipes.rb
+++ b/lib/dotenv/capistrano/recipes.rb
@@ -1,10 +1,11 @@
 Capistrano::Configuration.instance(:must_exist).load do
   _cset(:dotenv_path){ "#{shared_path}/.env" }
-  _cset(:dotenv_role){ [:app] }
+
+  symlink_args = (role = fetch(:dotenv_role, nil) ? {roles: role} : {})
 
   namespace :dotenv do
     desc "Symlink shared .env to current release"
-    task :symlink, roles: lambda { dotenv_role } do
+    task :symlink, symlink_args do
       run "ln -nfs #{dotenv_path} #{release_path}/.env"
     end
   end


### PR DESCRIPTION
Add the `dotenv_role` configuration variable. Since now, `dotenv:symlink` was only executed on **app** server. It's still the case by default but you can now easily override it.

``` RUBY
set :dotenv_role, [:app, :web]
```

/cc @ichilton 
