### PR TITLE
Add Dotenv.ensure

### DIFF
--- a/lib/dotenv.rb
+++ b/lib/dotenv.rb
@@ -1,6 +1,8 @@
 require 'dotenv/environment'
 
 module Dotenv
+  class MissingEnvironmentVariable < StandardError; end
+
   def self.load(*filenames)
     default_if_empty(filenames).inject({}) do |hash, filename|
       filename = File.expand_path filename
@@ -16,6 +18,13 @@ module Dotenv
         raise(Errno::ENOENT.new(filename)) unless File.exists?(filename)
       end
     )
+  end
+
+  def self.ensure(key)
+    if ENV[key].nil?
+      raise MissingEnvironmentVariable,
+        "Missing required environment variable #{key}"
+    end
   end
 
 protected

--- a/spec/dotenv_spec.rb
+++ b/spec/dotenv_spec.rb
@@ -82,6 +82,22 @@ describe Dotenv do
     end
   end
 
+  describe 'ensure' do
+
+    it 'raises an error if the specified ENV variable is not set' do
+      expect { Dotenv.ensure('DOTENV_ENSURE_TEST_BAD') }.
+        to raise_error(Dotenv::MissingEnvironmentVariable)
+    end
+
+    it 'passes if the speicified ENV variable is set' do
+      ENV['DOTENV_ENSURE_TEST_GOOD'] = 'filled in'
+
+      expect { Dotenv.ensure('DOTENV_ENSURE_TEST_GOOD') }.
+        not_to raise_error
+    end
+
+  end
+
   def fixture_path(name)
     File.join(File.expand_path('../fixtures', __FILE__), name)
   end


### PR DESCRIPTION
I started writing in some checks into my app that ensured certain ENV variables were set when new developers (or myself on a new machine) clone the app, start working, then get vague errors about method_missing on nil. 

I know standard practice is to set a .env.example, but I'm also trying to think of a way to manage config requirements in-app based on certain contexts. For instance, my app may want to use AWS, thus needing AWS env vars, but not worry about setting Rackspace configs.

Future improvements could include descriptions of what these ENV variables are supposed to contain.

This may also enable the creation of a tool to analyze code for calls to Dotenv.ensure and generate a .env.example.
