### PR TITLE
Enable execution of interpolated shell commands

### DIFF
--- a/lib/dotenv/environment.rb
+++ b/lib/dotenv/environment.rb
@@ -67,14 +67,16 @@ module Dotenv
             value = value.sub(parts[0...-1].join(''), replace || '')
           end
 
-          # Process interpolated shell commands
-          value.gsub!(INTERPOLATED_SHELL_COMMAND) do |*|
-            command = $~[:cmd][1..-2] # Eliminate opening and closing parentheses
+          if RUBY_VERSION > '1.8.7'
+            # Process interpolated shell commands
+            value.gsub!(INTERPOLATED_SHELL_COMMAND) do |*|
+              command = $~[:cmd][1..-2] # Eliminate opening and closing parentheses
 
-            if $~[:backslash]
-              $~[0][1..-1]
-            else
-              `#{command}`.chomp
+              if $~[:backslash]
+                $~[0][1..-1]
+              else
+                `#{command}`.chomp
+              end
             end
           end
 

--- a/spec/dotenv/environment_spec.rb
+++ b/spec/dotenv/environment_spec.rb
@@ -125,24 +125,26 @@ describe Dotenv::Environment do
     expect(env("foo='ba#r'")).to eql('foo' => 'ba#r')
   end
 
-  it 'parses shell commands interpolated in $()' do
-    expect(env('ruby_v=$(ruby -v)')).to eql('ruby_v' => RUBY_DESCRIPTION)
-  end
+  if RUBY_VERSION > '1.8.7'
+    it 'parses shell commands interpolated in $()' do
+      expect(env('ruby_v=$(ruby -v)')).to eql('ruby_v' => RUBY_DESCRIPTION)
+    end
 
-  it 'allows balanced parentheses within interpolated shell commands' do
-    expect(env('ruby_v=$(echo "$(echo "$(echo "$(ruby -v)")")")')).to eql('ruby_v' => RUBY_DESCRIPTION)
-  end
+    it 'allows balanced parentheses within interpolated shell commands' do
+      expect(env('ruby_v=$(echo "$(echo "$(echo "$(ruby -v)")")")')).to eql('ruby_v' => RUBY_DESCRIPTION)
+    end
 
-  it "doesn't interpolate shell commands when escape says not to" do
-    expect(env('ruby_v=escaped-\$(ruby -v)')).to eql('ruby_v' => 'escaped-$(ruby -v)')
-  end
+    it "doesn't interpolate shell commands when escape says not to" do
+      expect(env('ruby_v=escaped-\$(ruby -v)')).to eql('ruby_v' => 'escaped-$(ruby -v)')
+    end
 
-  it 'is not thrown off by quotes in interpolated shell commands' do
-    expect(env('interp=$(echo "Quotes won\'t be a problem")')['interp']).to eql("Quotes won't be a problem")
-  end
+    it 'is not thrown off by quotes in interpolated shell commands' do
+      expect(env('interp=$(echo "Quotes won\'t be a problem")')['interp']).to eql("Quotes won't be a problem")
+    end
 
-  it 'substitutes shell variables within interpolated shell commands' do
-    expect(env(%(VAR1=var1\ninterp=$(echo "VAR1 is $VAR1")))['interp']).to eql("VAR1 is var1")
+    it 'substitutes shell variables within interpolated shell commands' do
+      expect(env(%(VAR1=var1\ninterp=$(echo "VAR1 is $VAR1")))['interp']).to eql("VAR1 is var1")
+    end
   end
 
   require 'tempfile'


### PR DESCRIPTION
Addresses issue https://github.com/bkeepers/dotenv/issues/53

This addition allows the insertion of shell commands on the right-hand side of env variable assignments, using the `$(...)` notation.

The feature is disabled for Ruby versions <= 1.8.7. I found it most effective to use a recursive expression in the regex, in order to support parentheses inside embedded commands.
