### PR TITLE
Fix specs on ruby 1.8.7/ree

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ rvm:
   - 1.9.3
   - 1.8.7
   - ree
+bundler_args: --without=guard

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 gemspec :name => 'dotenv'
 
-gem 'guard-rspec'
-gem 'guard-bundler'
-gem 'rb-fsevent'
+group :guard do
+  gem 'guard-rspec'
+  gem 'guard-bundler'
+  gem 'rb-fsevent'
+end


### PR DESCRIPTION
The travis build has been failing due to a guard dependency only working with Ruby 1.9. This puts the guard deps in a bundler group and excludes them on CI, since they're only used for local development.
