### PR TITLE
Fix legacy Ruby versions

### DIFF
--- a/lib/dotenv/environment_extensions/interpolated_shell_commands.rb
+++ b/lib/dotenv/environment_extensions/interpolated_shell_commands.rb
@@ -3,25 +3,32 @@ module Dotenv
 
     module IterpolatedShellCommands
 
-      INTERPOLATED_SHELL_COMMAND = /
-        (?<backslash>\\)?
-        \$
-        (?<cmd>             # collect command content for eval
-          \(                # require opening paren
-          ([^()]|\g<cmd>)+  # allow any number of non-parens, or balanced parens (by nesting the <cmd> expression recursively)
-          \)                # require closing paren
-        )
-      /x
+      class << self
 
-      def process_interpolated_shell_commands(value)
-        # Process interpolated shell commands
-        value.gsub(INTERPOLATED_SHELL_COMMAND) do |*|
-          command = $~[:cmd][1..-2] # Eliminate opening and closing parentheses
+        INTERPOLATED_SHELL_COMMAND = /
+          (?<backslash>\\)?
+          \$
+          (?<cmd>             # collect command content for eval
+            \(                # require opening paren
+            ([^()]|\g<cmd>)+  # allow any number of non-parens, or balanced parens (by nesting the <cmd> expression recursively)
+            \)                # require closing paren
+          )
+        /x
 
-          if $~[:backslash]
-            $~[0][1..-1]
-          else
-            `#{command}`.chomp
+        def included(base)
+          base.register_load_extension(method(:process_interpolated_shell_commands))
+        end
+
+        def process_interpolated_shell_commands(value)
+          # Process interpolated shell commands
+          value.gsub(INTERPOLATED_SHELL_COMMAND) do |*|
+            command = $~[:cmd][1..-2] # Eliminate opening and closing parentheses
+
+            if $~[:backslash]
+              $~[0][1..-1]
+            else
+              `#{command}`.chomp
+            end
           end
         end
       end


### PR DESCRIPTION
The current codebase doesn't work correctly with Ruby <= 1.9 because even though @jcamenisch did add some good Ruby 1.8.7 conditions into the codebase, [the `INTERPOLATED_SHELL_COMMAND` Regexp](https://github.com/bkeepers/dotenv/blob/837021444301b355f6be9878436adcb370539ca1/lib/dotenv/environment.rb#L29-L37) is still defined using a lookbehind syntax that isn't supported by older versions of Ruby. This has caused some of [the latest Travis builds](https://travis-ci.org/bkeepers/dotenv/jobs/13840719) fail with a `SyntaxError`.

This pull request resolves this problem by moving the definition of the `INTERPOLATED_SHELL_COMMAND` Regexp into a completely separate .rb file that is only required when modern versions of Ruby are used.

With this pull request, all tests are now [passing on all environments!](https://travis-ci.org/metavida/dotenv/builds/14424488)
