### PR TITLE
Move variable substitution to an extension

### DIFF
--- a/lib/dotenv/substitutions/command.rb
+++ b/lib/dotenv/substitutions/command.rb
@@ -1,8 +1,6 @@
 module Dotenv
-  module EnvironmentExtensions
-
-    module IterpolatedShellCommands
-
+  module Substitutions
+    module Command
       class << self
 
         INTERPOLATED_SHELL_COMMAND = /
@@ -15,11 +13,7 @@ module Dotenv
           )
         /x
 
-        def included(base)
-          base.register_load_extension(method(:process_interpolated_shell_commands))
-        end
-
-        def process_interpolated_shell_commands(value, env)
+        def call(value, env)
           # Process interpolated shell commands
           value.gsub(INTERPOLATED_SHELL_COMMAND) do |*|
             command = $~[:cmd][1..-2] # Eliminate opening and closing parentheses

--- a/lib/dotenv/substitutions/variable.rb
+++ b/lib/dotenv/substitutions/variable.rb
@@ -1,8 +1,6 @@
 module Dotenv
-  module EnvironmentExtensions
-
+  module Substitutions
     module Variable
-
       class << self
 
         VARIABLE = /
@@ -15,11 +13,7 @@ module Dotenv
           )
         /xi
 
-        def included(base)
-          base.register_load_extension(method(:process_variables))
-        end
-
-        def process_variables(value, env)
+        def call(value, env)
           # Process embedded variables
           value.scan(VARIABLE).each do |parts|
             if parts.first == '\\'


### PR DESCRIPTION
This incorporates the changes from @metavida in #75 of moving shell interpolation into an extension. I also moved variable substitution out, change the naming from "extension" to "substitution", and concealed the external API methods for now. I don't want to expose something that people start using until we like it internally.

I still don't love the pattern of having a module with a `#call` method, but it works for now.
