### PR TITLE
Restrict build status to master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dotenv [![Build Status](https://secure.travis-ci.org/bkeepers/dotenv.png)](https://travis-ci.org/bkeepers/dotenv)
+# dotenv [![Build Status](https://secure.travis-ci.org/bkeepers/dotenv.png?branch=master)](https://travis-ci.org/bkeepers/dotenv)
 
 Dotenv loads environment variables from `.env` into `ENV`.
 


### PR DESCRIPTION
Currently the build status badge is shown as failing because of failing tests in a branch. This restricts the build status badge to the master branch only.
