### PR TITLE
Travis - Ruby 2.1.0, Rubinius, JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: ruby
 rvm:
+  - 2.1.0
   - 2.0.0
   - 1.9.3
   - 1.8.7
   - ree
+  - jruby-19mode
+  - rbx
 bundler_args: --without=guard

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,7 @@ group :guard do
   gem 'guard-bundler'
   gem 'rb-fsevent'
 end
+
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'         # if using anything in the ruby standard library
+end

--- a/spec/dotenv/environment_spec.rb
+++ b/spec/dotenv/environment_spec.rb
@@ -142,8 +142,11 @@ describe Dotenv::Environment do
       expect(env('interp=$(echo "Quotes won\'t be a problem")')['interp']).to eql("Quotes won't be a problem")
     end
 
-    it 'substitutes shell variables within interpolated shell commands' do
-      expect(env(%(VAR1=var1\ninterp=$(echo "VAR1 is $VAR1")))['interp']).to eql("VAR1 is var1")
+    # This functionality is not supported on JRuby or Rubinius
+    if (!defined?(RUBY_ENGINE) || RUBY_ENGINE != 'jruby') && !defined?(Rubinius)
+      it 'substitutes shell variables within interpolated shell commands' do
+        expect(env(%(VAR1=var1\ninterp=$(echo "VAR1 is $VAR1")))['interp']).to eql("VAR1 is var1")
+      end
     end
   end
 

--- a/spec/dotenv_spec.rb
+++ b/spec/dotenv_spec.rb
@@ -6,7 +6,7 @@ describe Dotenv do
       let(:env_files) { [] }
 
       it 'defaults to .env' do
-        Dotenv::Environment.should_receive(:new).with(expand('.env')).
+        expect(Dotenv::Environment).to receive(:new).with(expand('.env')).
           and_return(double(:apply => {}))
         subject
       end
@@ -17,8 +17,8 @@ describe Dotenv do
 
       it 'expands the path' do
         expected = expand("~/.env")
-        File.stub(:exists?){ |arg| arg == expected }
-        Dotenv::Environment.should_receive(:new).with(expected).
+        allow(File).to receive(:exists?){ |arg| arg == expected }
+        expect(Dotenv::Environment).to receive(:new).with(expected).
           and_return(double(:apply => {}))
         subject
       end


### PR DESCRIPTION
1. Added Ruby 2.1.0, Rubinius, JRuby to Travis config.
2. Updated deprecated syntax in specs to match the other specs.
3. Added Rubinius gems to Gemfile.

JRuby and Rubinius have allowed failures because they don't support the embedded shell behavior that is available on MRI VMs.
