### PR TITLE
Adding the ability to copy keys from .env to .env.example

### DIFF
--- a/bin/dotenv
+++ b/bin/dotenv
@@ -2,11 +2,19 @@
 
 require "dotenv"
 
-begin
-  Dotenv.load!
-rescue Errno::ENOENT => e
-  warn e.message
-  exit 1
+if ARGV[0] == 'example:load'
+  # Load keys from your .env file into .env.example
+  # Usage: `$ dotenv example:load`
+  keys = Dotenv.load.keys.map{|key| key + ':'}
+  File.open('.env.example', 'w+') {|f| f.write(keys.join("\n")) }
+  puts "Copied keys from .env to .env.example"
 else
-  exec *ARGV
+  begin
+    Dotenv.load!
+  rescue Errno::ENOENT => e
+    warn e.message
+    exit 1
+  else
+    exec *ARGV
+  end
 end


### PR DESCRIPTION
Often with open source, .env files are simply kept in the .gitignore. This is great until someone else comes along and tries to setup their own .env. The solution is often to create a .env.example file, that contains the environment variable keys, but not their values. This is often somewhat hard to keep up to date.

This PR adds a command to create a .env.example file based on the keys from your .env. It can be used by running `dotenv example:load` in your repo. This way, you can safely keep your sensitive keys from your .env in your .gitignore, and easily update your .env.example.

Right now I have added the logic for this to bin/dotenv. If anyone has an idea for a better place to put it, I'm all ears.
