### PR TITLE
Ruby 1.8 compatibility

### DIFF
--- a/lib/dotenv/capistrano/recipes.rb
+++ b/lib/dotenv/capistrano/recipes.rb
@@ -1,7 +1,7 @@
 Capistrano::Configuration.instance(:must_exist).load do
   _cset(:dotenv_path){ "#{shared_path}/.env" }
 
-  symlink_args = (role = fetch(:dotenv_role, nil) ? {roles: role} : {})
+  symlink_args = (role = fetch(:dotenv_role, nil) ? {:roles => role} : {})
 
   namespace :dotenv do
     desc "Symlink shared .env to current release"


### PR DESCRIPTION
All dotenv is Ruby 1.8 compatible but not the capistrano recipes.
