### PR TITLE
Mention 'dotenv' executable in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ require 'dotenv'
 Dotenv.load
 ```
 
+Alternatively, you can use the `dotenv` executable to launch your application:
+
+```shell
+$ dotenv ./script.py
+```
+
 To ensure `.env` is loaded in rake, load the tasks:
 
 ```ruby


### PR DESCRIPTION
The `dotenv` executable is easy to miss yet useful in many situations. Mention it in the documentation.

Following the example set by the changelog, refer to a Python script in the documentation to underline the point that using Dotenv this way is not specific to Ruby.
