### PR TITLE
Handle missing arguments in 'dotenv' executable

### DIFF
--- a/bin/dotenv
+++ b/bin/dotenv
@@ -7,5 +7,5 @@ begin
 rescue Errno::ENOENT => e
   abort e.message
 else
-  exec *ARGV
+  exec *ARGV unless ARGV.empty?
 end


### PR DESCRIPTION
If the `dotenv` executable is called without arguments, it fails with an `ArgumentError`. Handle this situation gracefully by exiting silently.

We could also display an usage message, but I like to think the program is quite self-explanatory. Another option would be to display `ENV` as `env` does. Thoughts?
