### PR TITLE
Add ommited license to dotenv-rails.gemspec

### DIFF
--- a/dotenv-rails.gemspec
+++ b/dotenv-rails.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{Autoload dotenv in Rails.}
   gem.summary       = %q{Autoload dotenv in Rails.}
   gem.homepage      = "https://github.com/bkeepers/dotenv"
+  gem.license       = 'MIT'
 
   gem.files         = ["lib/dotenv-rails.rb"]
   gem.name          = "dotenv-rails"


### PR DESCRIPTION
dotenv-rails.gemspec was missing the license directive. I set it to MIT, like the dotenv gem and the source repo itself.
