### PR TITLE
support square brackets as key name

### DIFF
--- a/lib/dotenv/parser.rb
+++ b/lib/dotenv/parser.rb
@@ -12,7 +12,7 @@ module Dotenv
     LINE = /
       \A
       (?:export\s+)?    # optional export
-      ([\w\.]+)         # key
+      ([\w\.\]\[]+)     # key
       (?:\s*=\s*|:\s+?) # separator
       (                 # optional value begin
         '(?:\'|[^'])*'  #   single quoted value

--- a/spec/dotenv/parser_spec.rb
+++ b/spec/dotenv/parser_spec.rb
@@ -101,6 +101,15 @@ describe Dotenv::Parser do
     expect(env("foo='ba#r'")).to eql('foo' => 'ba#r')
   end
 
+  it 'support square-brackets as key names both lower and uppercase' do
+    expect(env('foo[one]="two"')).to eql('foo[one]' => 'two')
+    expect(env('FOO[BAR]="one"')).to eql('FOO[BAR]' => 'one')
+  end
+
+  it 'support multi-dimensional square-brackets as key name' do
+    expect(env('foo[one][two]="three"')).to eql('foo[one][two]' => 'three')
+  end
+
   if RUBY_VERSION > '1.8.7'
     it 'parses shell commands interpolated in $()' do
       expect(env('ruby_v=$(ruby -v)')).to eql('ruby_v' => RUBY_DESCRIPTION)


### PR DESCRIPTION
The use case here is similar to the way params supports hash objects by doing

```
params[hsh][key] = value
params[hsh][key2] = value2
```

I would like to do something similar using an .env file. The format is also supported by heroku, i.e. I can create a keyname containing square-brackets using their heroku config:set command.
