### PR TITLE
Add ability to load env-t settings from each *.env file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+.idea
 Gemfile.lock
 tmp
 vendor

--- a/lib/dotenv/railtie.rb
+++ b/lib/dotenv/railtie.rb
@@ -3,12 +3,12 @@ require 'dotenv'
 module Dotenv
   class Railtie < Rails::Railtie
     rake_tasks do
-      desc 'Load environment settings from .env'
+      desc 'Load environment settings from each *.env file'
       task :dotenv do
-        Dotenv.load ".env.#{Rails.env}", '.env'
+        Dotenv.load ".env.#{Rails.env}", '.env', *Dir.glob("#{Rails.root}/**/*.env")
       end
     end
   end
 end
 
-Dotenv.load ".env.#{Rails.env}", '.env'
+Dotenv.load ".env.#{Rails.env}", '.env', *Dir.glob("#{Rails.root}/**/*.env")


### PR DESCRIPTION
I think it would be a good idea to autoload settings from any *.env file in Rails app in addition to '.env' or ".env.#{Rails.env}". 

With this little patch we can create files: 
- "config/environments/constants.env" (All non-secret constants) 
- "tokens.env" (file with secrets).

This would be helpful for capistrano deployment:

```
set :linked_files, %w{config/database.yml config/environments/tokens.env}
```

We can link only tokens.env, without constants.env. 

In addition I think 'semantic_name.env' would be more semantic than just '.env'.

Thanks in advance for your attention!

UPDATE: All previous '.env' and '.env.*' conventions will work as before.
