### PR TITLE
Allow .env.local overrides

### DIFF
--- a/lib/dotenv-rails.rb
+++ b/lib/dotenv-rails.rb
@@ -8,4 +8,4 @@ if File.exists?(env_file) && !defined?(Dotenv::Deployment)
   Dotenv.load ".env.#{Rails.env}"
 end
 
-Dotenv.load '.env'
+Dotenv.load '.env', '.env.local'


### PR DESCRIPTION
For context, we're checking `.env` into source control with default development environment settings.

However, like #111 we want to override these on a per-machine basis. Previously we were using `.env.development`, but this has since been deprecated.

I want to propose a new `.env.local` as a standard recommended place to keep machine-specific overrides, with the idea being that it's not checked into source control.

Thoughts?