### PR TITLE
Add `export` section to usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ S3_BUCKET=YOURS3BUCKET
 SECRET_KEY=YOURSECRETKEYGOESHERE
 ```
 
+You may also add `export` in front of each line so you can `source` the file in bash:
+
+```shell
+export S3_BUCKET=YOURS3BUCKET
+export SECRET_KEY=YOURSECRETKEYGOESHERE
+```
+
 An alternate yaml-like syntax is supported:
 
 ```yaml


### PR DESCRIPTION
Adding `export` is allowed at the front of each line, this lets you
create a file that can be sourced by bash. This should be in the README.
