### PR TITLE
Watch .env for changes with Spring in Rails 4

### DIFF
--- a/lib/dotenv-rails.rb
+++ b/lib/dotenv-rails.rb
@@ -9,3 +9,5 @@ if File.exists?(env_file) && !defined?(Dotenv::Deployment)
 end
 
 Dotenv.load '.env'
+
+Spring.watch '.env' if defined?(Spring)


### PR DESCRIPTION
It would be really nice to watch any files loaded by `Dotenv.load`, but we would need to add some other tracking to make that happen.

Closes #117 
