### PR TITLE
use rbx-2 to fix travis issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ rvm:
   - 1.8.7
   - ree
   - jruby-19mode
-  - rbx
+  - rbx-2
 bundler_args: --without=guard


### PR DESCRIPTION
It looks like there's an issue with rvm when using just `rbx`. `rbx-2` fixes it.
