### PR TITLE
Return of multiple environments in dotenv-rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
 # dotenv [![Build Status](https://secure.travis-ci.org/bkeepers/dotenv.png?branch=master)](https://travis-ci.org/bkeepers/dotenv)
 
-Shim to load environment variables from `.env` into `ENV` in *development*.
+Shim to load environment variables from `.env` into `ENV`.
 
 Storing [configuration in the environment](http://www.12factor.net/config) is one of the tenets of a [twelve-factor app](http://www.12factor.net/). Anything that is likely to change between deployment environments–such as resource handles for databases or credentials for external services–should be extracted from the code into environment variables.
 
 But it is not always practical to set environment variables on development machines or continuous integration servers where multiple projects are run. dotenv loads variables from a `.env` file into `ENV` when the environment is bootstrapped.
-
-dotenv is intended to be used in development. If you would like to use it in production or other environments, see [dotenv-deployment](https://github.com/bkeepers/dotenv-deployment)
-
 
 ## Installation
 
@@ -86,6 +83,14 @@ Whenever your application loads, these variables will be available in `ENV`:
 ```ruby
 config.fog_directory  = ENV['S3_BUCKET']
 ```
+
+## Multiple Rails Environments
+
+dotenv was originally created to load configuration variables into `ENV` in *development*. There are typically better ways to manage configuration in production environments environments—such as `/etc/environment` managed by [Puppet](https://github.com/puppetlabs/puppet) or [Chef](https://github.com/opscode/chef), `heroku config`, etc.
+
+However, some find dotenv to be a convenient way to configure applications in staging and production environments, and you can do that by defining environment-specific files like `.env.production` or `.env.test`.
+
+Values defined in `.env` will not override existing environment variables, but values defined in environment-specific files will override any existing environment variables.
 
 ## Should I commit my .env file?
 

--- a/lib/dotenv-rails.rb
+++ b/lib/dotenv-rails.rb
@@ -1,16 +1,13 @@
 require 'dotenv/railtie'
 
 # Load defaults from config/*.env or .env
-Dotenv.load *Dir.glob("#{Rails.root}/config/**/*.env").push('.env')
+Dotenv.load '.env'
 
 # Override any existing variables if an environment-specific file exists
-envs = *Dir.glob("#{Rails.root}/config/**/*.#{Rails.env}.env").push(
-  ".#{Rails.env}.env",
-  ".env.#{Rails.env}"
-)
+envs =  [".#{Rails.env}.env", ".env.#{Rails.env}"]
 Dotenv.overload *envs
 
 # Allow local overrides in .env.local or config/local.env
-Dotenv.overload Rails.root.join('.local.env'), Rails.root.join("config/local.env")
+Dotenv.overload Rails.root.join('.local.env')
 
 Spring.watch '.env' if defined?(Spring)

--- a/lib/dotenv-rails.rb
+++ b/lib/dotenv-rails.rb
@@ -11,4 +11,4 @@ envs = *Dir.glob("#{Rails.root}/config/**/*.#{Rails.env}.env").push(
 Dotenv.overload *envs
 
 # Allow local overrides in .env.local or config/local.env
-Dotenv.overload Rails.root.join('.env.local'), Rails.root.join("config/local.env")
+Dotenv.overload Rails.root.join('.local.env'), Rails.root.join("config/local.env")

--- a/lib/dotenv-rails.rb
+++ b/lib/dotenv-rails.rb
@@ -1,11 +1,10 @@
 require 'dotenv/railtie'
 
-env_file = ".env.#{Rails.env}"
-if File.exists?(env_file) && !defined?(Dotenv::Deployment)
-  warn "Auto-loading of `#{env_file}` will be removed in 1.0. See " +
-    "https://github.com/bkeepers/dotenv-deployment if you would like to " +
-    "continue using this feature."
-  Dotenv.load ".env.#{Rails.env}"
-end
+# Load defaults from config/*.env  or .env
+Dotenv.load *Dir.glob("#{Rails.root}/config/**/*.env").push('.env')
 
-Dotenv.load '.env'
+# Override any existing variables if an environment-specific file exists
+Dotenv.overload *Dir.glob("#{Rails.root}/config/**/*.env.#{Rails.env}").push(".env.#{Rails.env}")
+
+# Allow local overrides in .env.local or config/local.env
+Dotenv.overload Rails.root.join('.env.local'), Rails.root.join("config/local.env")

--- a/lib/dotenv-rails.rb
+++ b/lib/dotenv-rails.rb
@@ -1,10 +1,14 @@
 require 'dotenv/railtie'
 
-# Load defaults from config/*.env  or .env
+# Load defaults from config/*.env or .env
 Dotenv.load *Dir.glob("#{Rails.root}/config/**/*.env").push('.env')
 
 # Override any existing variables if an environment-specific file exists
-Dotenv.overload *Dir.glob("#{Rails.root}/config/**/*.env.#{Rails.env}").push(".env.#{Rails.env}")
+envs = *Dir.glob("#{Rails.root}/config/**/*.#{Rails.env}.env").push(
+  ".#{Rails.env}.env",
+  ".env.#{Rails.env}"
+)
+Dotenv.overload *envs
 
 # Allow local overrides in .env.local or config/local.env
 Dotenv.overload Rails.root.join('.env.local'), Rails.root.join("config/local.env")

--- a/lib/dotenv-rails.rb
+++ b/lib/dotenv-rails.rb
@@ -1,13 +1,16 @@
 require 'dotenv/railtie'
 
 # Load defaults from config/*.env or .env
-Dotenv.load '.env'
+Dotenv.load Rails.root.join('.env')
 
 # Override any existing variables if an environment-specific file exists
-envs =  [".#{Rails.env}.env", ".env.#{Rails.env}"]
+envs =  [
+  Rails.root.join(".#{Rails.env}.env"),
+  Rails.root.join(".env.#{Rails.env}"
+]
 Dotenv.overload *envs
 
 # Allow local overrides in .env.local or config/local.env
-Dotenv.overload Rails.root.join('.local.env')
+Dotenv.overload Rails.root.join('.local.env'), Rails.root.join('.local.env')
 
-Spring.watch '.env' if defined?(Spring)
+Spring.watch Rails.root.join('.env') if defined?(Spring)


### PR DESCRIPTION
This is a bit of an about-face for my stance on supporting multiple environments with `dotenv-rails`. I think #95 has mostly just frustrated people and caused confusion. I'd like to get this right before releasing 1.0 (#108)

This attempts to solve what originally annoyed me about the multiple environment support by being a little more aggressive about what is loaded.

First it will load `config/**/*.env` and `.env` without overriding existing variables.  Then it loads `config/**/*.#{Rails.env}.env`, `.#{Rails.env}.env`, and  `.env.#{Rails.env}` (may eventually be deprecated), overriding existing values. Finally, it loads `config/local.env` and `.local.env`, overriding existing values. These are intended to be added to `.gitignore`.

**TODO:**

- [x] update README

closes #111
closes #113 

/cc @technicalpickles