### PR TITLE
File.exists? is now deprecated in Ruby, use File.exist? instead

### DIFF
--- a/lib/dotenv-rails.rb
+++ b/lib/dotenv-rails.rb
@@ -1,7 +1,7 @@
 require 'dotenv/railtie'
 
 env_file = ".env.#{Rails.env}"
-if File.exists?(env_file) && !defined?(Dotenv::Deployment)
+if File.exist?(env_file) && !defined?(Dotenv::Deployment)
   warn "Auto-loading of `#{env_file}` will be removed in 1.0. See " +
     "https://github.com/bkeepers/dotenv-deployment if you would like to " +
     "continue using this feature."

--- a/lib/dotenv.rb
+++ b/lib/dotenv.rb
@@ -3,7 +3,7 @@ require 'dotenv/environment'
 
 module Dotenv
   def self.load(*filenames)
-    with(*filenames) { |f| Environment.new(f).apply if File.exists?(f) }
+    with(*filenames) { |f| Environment.new(f).apply if File.exist?(f) }
   end
 
   # same as `load`, but raises Errno::ENOENT if any files don't exist
@@ -13,7 +13,7 @@ module Dotenv
 
   # same as `load`, but will override existing values in `ENV`
   def self.overload(*filenames)
-    with(*filenames) { |f| Environment.new(f).apply! if File.exists?(f) }
+    with(*filenames) { |f| Environment.new(f).apply! if File.exist?(f) }
   end
 
 protected

--- a/spec/dotenv_spec.rb
+++ b/spec/dotenv_spec.rb
@@ -17,7 +17,7 @@ describe Dotenv do
 
       it 'expands the path' do
         expected = expand("~/.env")
-        allow(File).to receive(:exists?){ |arg| arg == expected }
+        allow(File).to receive(:exist?){ |arg| arg == expected }
         expect(Dotenv::Environment).to receive(:new).with(expected).
           and_return(double(:apply => {}, :apply! => {}))
         subject


### PR DESCRIPTION
Hello,

`File.exists` is deprecated on recent versions of Ruby.
This commit removes some warnings when we load dotenv in a project.
`warning: File.exists? is a deprecated name, use File.exist? instead`

Here is the deprecation code in the Ruby repository:
https://github.com/ruby/ruby/blob/trunk/file.c#L1462
