### PR TITLE
Use Rails root

### DIFF
--- a/lib/dotenv-rails.rb
+++ b/lib/dotenv-rails.rb
@@ -1,13 +1,13 @@
 require 'dotenv/railtie'
 
-env_file = ".env.#{Rails.env}"
+env_file = Rails.root.join(".env.#{Rails.env}")
 if File.exist?(env_file) && !defined?(Dotenv::Deployment)
   warn "Auto-loading of `#{env_file}` will be removed in 1.0. See " +
     "https://github.com/bkeepers/dotenv-deployment if you would like to " +
     "continue using this feature."
-  Dotenv.load ".env.#{Rails.env}"
+  Dotenv.load env_file
 end
 
-Dotenv.load '.env'
+Dotenv.load Rails.root.join('.env')
 
-Spring.watch '.env' if defined?(Spring)
+Spring.watch Rails.root.join('.env') if defined?(Spring)


### PR DESCRIPTION
Hi,

I found dotenv-rails uses `.env` file in the current working directory, so it doesn't load the env when the gem is loaded from background tasks such as `delayed_job` which is not executed from `Rails.root` usually. I added `Rails.root` directory to the env file path since the env should be placed in `Rails.root` for `Rails`.

Could you consider to merge this change?
