### PR TITLE
Don't do substitutions if the variable is single quoted.

### DIFF
--- a/lib/dotenv/parser.rb
+++ b/lib/dotenv/parser.rb
@@ -48,8 +48,10 @@ module Dotenv
             value = value.gsub(/\\([^$])/, '\1')
           end
 
-          @@substitutions.each do |proc|
-            value = proc.call(value, hash)
+          if $1 != "'"
+            @@substitutions.each do |proc|
+              value = proc.call(value, hash)
+            end
           end
 
           hash[key] = value

--- a/spec/dotenv/parser_spec.rb
+++ b/spec/dotenv/parser_spec.rb
@@ -47,8 +47,12 @@ describe Dotenv::Parser do
     expect(env('BAR=$FOO')).to eql('BAR' => '')
   end
 
-  it 'expands variables in quoted strings' do
-    expect(env("FOO=test\nBAR='quote $FOO'")).to eql('FOO' => 'test', 'BAR' => 'quote test')
+  it 'expands variables in double quoted strings' do
+    expect(env("FOO=test\nBAR=\"quote $FOO\"")).to eql('FOO' => 'test', 'BAR' => 'quote test')
+  end
+
+  it 'does not expand variables in single quoted strings' do
+    expect(env("BAR='quote $FOO'")).to eql('BAR' => 'quote $FOO')
   end
 
   it 'does not expand escaped variables' do


### PR DESCRIPTION
I outlined this problem in issue #123

This will stop substitution from being run on environment variables that are single quoted.
