### PR TITLE
Support -f option to dotenv binary

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unreleased
+
+* Support -f option to dotenv binary, e.g. dotenv -f /path/to/.env,/path/to/another/.env
+
 ## 0.11.1 - Apr 22, 2014
 
 * Depend on dotenv-deployment ~>0.0.2, which fixes issues with 0.0.1

--- a/bin/dotenv
+++ b/bin/dotenv
@@ -2,10 +2,23 @@
 
 require 'dotenv'
 
+# don't bork input args
+argv = ARGV.dup
+
+filenames = if (pos = ARGV.index('-f'))
+  # drop the -f
+  argv.delete_at pos
+  # parse one or more comma-separated .env files
+  require 'csv'
+  CSV.parse_line argv.delete_at(pos)
+else
+  []
+end
+
 begin
-  Dotenv.load!
+  Dotenv.load! *filenames
 rescue Errno::ENOENT => e
   abort e.message
 else
-  exec *ARGV unless ARGV.empty?
+  exec *argv unless argv.empty?
 end

--- a/spec/dotenv/bin_spec.rb
+++ b/spec/dotenv/bin_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+require 'tmpdir'
+
+describe 'dotenv binary' do
+  let(:bin)     { 'bundle exec ' + File.expand_path('../../../bin/dotenv', __FILE__)}
+  let(:special) { rand.to_s }
+  let(:tmpdir)  { Dir.mktmpdir 'dotenv' }
+
+  before do
+    @last_dir = Dir.pwd
+    @last_bundle_gemfile = ENV.has_key?('BUNDLE_GEMFILE') ? ENV['BUNDLE_GEMFILE'] : false
+    Dir.chdir tmpdir
+    IO.write('Gemfile.tmp', "source 'https://rubygems.org'\ngemspec :name => 'dotenv', :path => '#{File.expand_path('../../..', __FILE__)}'")
+    ENV['BUNDLE_GEMFILE'] = 'Gemfile.tmp'
+  end
+
+  after do
+    Dir.chdir @last_dir
+    if @last_bundle_gemfile
+      ENV['BUNDLE_GEMFILE'] = @last_bundle_gemfile
+    else
+      ENV.delete 'BUNDLE_GEMFILE'
+    end
+  end
+
+  it "won't have a special env var without dotenv" do
+    expect(`env`).not_to include(special)
+  end
+
+  it "dies if no .env" do
+    expect(`#{bin} 2>&1`).to match(/no such file/i)
+    expect($?.success?).to be_falsy
+  end
+
+  it "loads from .env by default" do
+    IO.write('.env', "SPECIAL=#{special}")
+    expect(`#{bin} env`).to include("SPECIAL=#{special}")
+  end
+
+  it "loads from file specified by -f" do
+    other_env = ".env.#{rand.to_s}"
+    IO.write(other_env, "SPECIAL=#{special}")
+    expect(`#{bin} -f #{other_env} env`).to include("SPECIAL=#{special}")
+  end
+
+  it "dies if file specified by -f doesn't exist" do
+    expect(`#{bin} -f #{rand.to_s} 2>&1`).to match(/no such file/i)
+    expect($?.success?).to be_falsy
+  end
+
+  it "loads from multiple files specified by -f" do
+    other_env = ".env.#{rand.to_s}"
+    other_env_2 = ".env.#{rand.to_s}"
+    IO.write(other_env, "SPECIAL=#{special}")
+    IO.write(other_env_2, "SPECIAL2=#{special}")
+    out = `#{bin} -f #{other_env},#{other_env_2} env`
+    expect(out).to include("SPECIAL=#{special}")
+    expect(out).to include("SPECIAL2=#{special}")
+  end
+
+
+end


### PR DESCRIPTION
allow specifying which `.env` files to use

```console
dotenv -f /path/to/.env,/path/to/another/.env
```

comes with tests