### PR TITLE
Add newline support to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ S3_BUCKET=YOURS3BUCKET
 SECRET_KEY=YOURSECRETKEYGOESHERE
 ```
 
-If you need multiline variables, for example private keys, you can double quote strings and use the `/n` character for newlines:
+If you need multiline variables, for example private keys, you can double quote strings and use the `\n` character for newlines:
 
 ```shell
 PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nHkVN9…\n-----END DSA PRIVATE KEY-----\n"


### PR DESCRIPTION
I noticed that awhile back you had added newline expansion to `dotenv`, but could only find its documentation through a closed issue. This PR updates the documentation.
