### PR TITLE
Preserve customized .env when overloading

### DIFF
--- a/lib/dotenv.rb
+++ b/lib/dotenv.rb
@@ -3,25 +3,28 @@ require 'dotenv/environment'
 
 module Dotenv
   def self.load(*filenames)
-    with(*filenames) { |f| Environment.new(f).apply if File.exist?(f) }
+    with_base_env(*filenames) { |f| Environment.new(f).apply if File.exist?(f) }
   end
 
   # same as `load`, but raises Errno::ENOENT if any files don't exist
   def self.load!(*filenames)
-    with(*filenames) { |f| Environment.new(f).apply }
+    with_base_env(*filenames) { |f| Environment.new(f).apply }
   end
 
   # same as `load`, but will override existing values in `ENV`
   def self.overload(*filenames)
-    with(*filenames) { |f| Environment.new(f).apply! if File.exist?(f) }
+    without_base_env(*filenames) { |f| Environment.new(f).apply! if File.exist?(f) }
   end
 
-  # Internal: Helper to expand list of filenames.
-  #
-  # Returns a hash of all the loaded environment variables.
-  def self.with(*filenames, &block)
+  # Internal: Helpers to expand list of filenames.
+  # Returns a hash of all the loaded environment variables (including global .env)
+  def self.with_base_env(*filenames, &block)
     filenames << '.env' if filenames.empty?
+    without_base_env(*filenames, &block)
+  end
 
+  # Returns a hash of all the loaded environment variables
+  def self.without_base_env(*filenames, &block)
     {}.tap do |hash|
       filenames.each do |filename|
         hash.merge! block.call(File.expand_path(filename)) || {}

--- a/spec/dotenv_spec.rb
+++ b/spec/dotenv_spec.rb
@@ -1,17 +1,17 @@
 require 'spec_helper'
 
 describe Dotenv do
-  shared_examples 'load' do
-    context 'with no args' do
-      let(:env_files) { [] }
+  shared_examples 'loading without filenames' do
+    let(:env_files) { [] }
 
-      it 'defaults to .env' do
-        expect(Dotenv::Environment).to receive(:new).with(expand('.env')).
-          and_return(double(:apply => {}, :apply! => {}))
-        subject
-      end
+    it 'defaults to .env' do
+      expect(Dotenv::Environment).to receive(:new).with(expand('.env')).
+        and_return(double(:apply => {}, :apply! => {}))
+      subject
     end
+  end
 
+  shared_examples 'load' do
     context 'with a tilde path' do
       let(:env_files) { ['~/.env'] }
 
@@ -53,6 +53,7 @@ describe Dotenv do
     subject { Dotenv.load(*env_files) }
 
     it_behaves_like 'load'
+    it_behaves_like 'loading without filenames'
 
     context 'when the file does not exist' do
       let(:env_files) { ['.env_does_not_exist'] }
@@ -68,6 +69,7 @@ describe Dotenv do
     subject { Dotenv.load!(*env_files) }
 
     it_behaves_like 'load'
+    it_behaves_like 'loading without filenames'
 
     context 'when one file exists and one does not' do
       let(:env_files) { ['.env', '.env_does_not_exist'] }


### PR DESCRIPTION
This resolves https://github.com/bkeepers/dotenv-deployment/issues/13

`overload()` should not push the `.env` file onto the `filenames` stack if is empty.  See issue link above for more detail.



