### PR TITLE
Remove jruby from travis until failure is resolved

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,5 @@ rvm:
   - 1.9.3
   - 1.8.7
   - ree
-  - jruby-19mode
   - rbx-2
 bundler_args: --without=guard


### PR DESCRIPTION
The build is error on jruby while trying to run bundle install. I haven't been able to figure out why, so I'm disabling it for now.

If anyone really cares about jruby, you're welcome to dig into it. https://travis-ci.org/bkeepers/dotenv/jobs/37002101

/cc @petergoldstein https://github.com/bkeepers/dotenv/pull/83
