### PR TITLE
Spring.watch requires 'spring/watcher' to work

### DIFF
--- a/lib/dotenv/railtie.rb
+++ b/lib/dotenv/railtie.rb
@@ -1,4 +1,5 @@
 require 'dotenv'
+require 'spring/watcher' if defined?(Spring)
 
 module Dotenv
   class Railtie < Rails::Railtie


### PR DESCRIPTION
I've got an error `undefined method 'watch' for Spring:Module` when using with Spring `1.1.3`
