### PR TITLE
support FOO[BAR][BAZ]=123

### DIFF
--- a/lib/dotenv/parser.rb
+++ b/lib/dotenv/parser.rb
@@ -12,7 +12,7 @@ module Dotenv
     LINE = /
       \A
       (?:export\s+)?    # optional export
-      ([\w\.]+)         # key
+      ([\w\.\[\]]+)      # key
       (?:\s*=\s*|:\s+?) # separator
       (                 # optional value begin
         '(?:\'|[^'])*'  #   single quoted value

--- a/spec/dotenv/parser_spec.rb
+++ b/spec/dotenv/parser_spec.rb
@@ -64,6 +64,10 @@ describe Dotenv::Parser do
     expect(env('OPTION_A: 1')).to eql('OPTION_A' => '1')
   end
 
+  it 'parses [/] keys' do
+    expect(env('F[O][O]=bar')).to eql('F[O][O]' => 'bar')
+  end
+
   it 'parses export keyword' do
     expect(env('export OPTION_A=2')).to eql('OPTION_A' => '2')
   end


### PR DESCRIPTION
@bkeepers 

we are converting a bunch of yml files to environment variables and though using this format was a nice replacement (we need to generate a hash with nested keys -> so we cannot just split on `_`)
