### PR TITLE
Allow Rails apps to use Dotenv.overload.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ require 'dotenv'
 Dotenv.load
 ```
 
+If you need to overload environment variables:
+
+```ruby
+require 'dotenv'
+Dotenv.overload
+```
+
 Alternatively, you can use the `dotenv` executable to launch your application:
 
 ```shell

--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -15,10 +15,18 @@ module Dotenv
     # This will get called during the `before_configuration` callback, but you
     # can manually call `Dotenv::Railtie.load` if you needed it sooner.
     def load
-      Dotenv.instrumenter = ActiveSupport::Notifications
-      configure_spring if defined?(Spring)
-
+      configure_load_options
       Dotenv.load Rails.root.join('.env')
+    end
+
+    # Public: Overload dotenv
+    #
+    # Manually called if you need to overload the values of existing
+    # environment variables. Useful if you are reloading environment as
+    # part of a zero-downtime deployment.
+    def overload
+      configure_load_options
+      Dotenv.overload Rails.root.join('.env')
     end
 
     # Internal: Watch all loaded env files with spring
@@ -33,6 +41,14 @@ module Dotenv
     # instance, which means `Kernel#load` gets called here. We don't want that.
     def self.load
       instance.load
+    end
+
+  private
+
+    # Internal: set up the instrumenter and configure Spring if Spring is loaded.
+    def configure_load_options
+      Dotenv.instrumenter = ActiveSupport::Notifications
+      configure_spring if defined?(Spring)
     end
   end
 end

--- a/spec/dotenv/rails_spec.rb
+++ b/spec/dotenv/rails_spec.rb
@@ -36,7 +36,7 @@ describe Dotenv::Railtie do
     end
   end
 
-  context 'load' do
+  context 'load methods' do
     before { Dotenv::Railtie.load }
 
     it 'watches .env with Spring' do
@@ -51,6 +51,24 @@ describe Dotenv::Railtie do
 
     it 'loads .env' do
       expect(ENV).to have_key('DOTENV')
+    end
+
+    context 'load' do
+      before { ENV['DOTENV'] = 'false' }
+
+      it 'does not overload .env' do
+        Dotenv::Railtie.load
+        expect(ENV['DOTENV']).to eq 'false'
+      end
+    end
+
+    context 'overload' do
+      before { ENV['DOTENV'] = 'false' }
+
+      it 'overloads .env' do
+        Dotenv::Railtie.overload
+        expect(ENV['DOTENV']).to eq 'true'
+      end
     end
   end
 end


### PR DESCRIPTION
Environment variables are currently only loaded if they are net-new, but we need to be able to update existing environment variables as well. This is necessary for our zero-downtime deployments.

* Moved duplicate calls to configure_spring and set instrumenter to a private method.
* Added paragraph on usage to README.md.
* Added tests for load and overload to test for updates to an existing environment variable.
* Created a context around the load and overload tests and moved common tests into that section.