### PR TITLE
Specific .env.{environment} file overrides .env

### DIFF
--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -18,7 +18,7 @@ module Dotenv
       Dotenv.instrumenter = ActiveSupport::Notifications
       configure_spring if defined?(Spring)
 
-      Dotenv.load Rails.root.join('.env')
+      Dotenv.load Rails.root.join(".env.#{Rails.env}"), Rails.root.join('.env')
     end
 
     # Internal: Watch all loaded env files with spring


### PR DESCRIPTION
It would be nice if the default .env file can be merged and overridden by environment specific .env files. The specific .env.{environment} file takes precedence.

Any thoughts?