### PR TITLE
Prepare for 2.0 beta release

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 1.1.0 - unreleased
+## 2.0.0 - unreleased
+
+* `.env.local` and `.env.#{Rails.env}` will be automatically be loaded with the `dotenv-rails` gem.
 
 * Drop official support for Ruby 1.8.7 and REE. They may still continue to work, but will not be tested against. Lock to version "<= 1.1" if you are using Ruby 1.8.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,12 @@
 # Changelog
 
-## 2.0.0 - unreleased
+## 2.0.0 - Mar 5, 2015
 
 * `.env.local` and `.env.#{Rails.env}` will be automatically be loaded with the `dotenv-rails` gem.
 
 * Drop official support for Ruby 1.8.7 and REE. They may still continue to work, but will not be tested against. Lock to version "<= 1.1" if you are using Ruby 1.8.
+
+* `dotenv-rails` now only supports Rails 4. Manually configure dotenv if you are using Rails 3.
 
 * Support -f option to dotenv executable
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@ source 'https://rubygems.org'
 gemspec :name => 'dotenv'
 gemspec :name => 'dotenv-rails'
 
-gem 'dotenv-deployment', :github => 'bkeepers/dotenv-deployment'
-
 group :guard do
   gem 'guard-rspec'
   gem 'guard-bundler'

--- a/dotenv-rails.gemspec
+++ b/dotenv-rails.gemspec
@@ -11,5 +11,5 @@ Gem::Specification.new "dotenv-rails", Dotenv::VERSION do |gem|
   gem.add_dependency 'dotenv', Dotenv::VERSION
 
   gem.add_development_dependency 'spring'
-  gem.add_development_dependency 'railties'
+  gem.add_development_dependency 'railties', '~>4.0'
 end

--- a/lib/dotenv/version.rb
+++ b/lib/dotenv/version.rb
@@ -1,3 +1,3 @@
 module Dotenv
-  VERSION = '1.0.2'
+  VERSION = '2.0.0.beta'
 end

--- a/lib/dotenv/version.rb
+++ b/lib/dotenv/version.rb
@@ -1,3 +1,3 @@
 module Dotenv
-  VERSION = "2.0.0.beta"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
https://github.com/bkeepers/dotenv/pull/159 adds back support for `.env.#{Rails.env}` that was removed in /cc https://github.com/bkeepers/dotenv/pull/95, so I'm going to bump the major version to indicate the change in functionality and push out a beta release to make sure there are no major issues with it.

Once this is released, I will probably deprecate the `dotenv-deployment` gem (or see if someone else wants to maintain it).
