### PR TITLE
dotenvcrypt branch for encrypting files

### DIFF
--- a/lib/dotenv.rb
+++ b/lib/dotenv.rb
@@ -6,32 +6,25 @@ module Dotenv
 
   attr_accessor :instrumenter
 
-  def load(*filenames)
-    with(*filenames) do |f|
-      if File.exist?(f)
-        env = Environment.new(f)
-        instrument('dotenv.load', :env => env) { env.apply }
+  def process(filename, optional, override)
+
+    # determine filename, return if not found and optional
+    if !File.exist?(filename)
+      if ENV.key?("DOTENVCRYPT") && File.exist?(dotenvcrypt = "#{filename}crypt")
+        filename = dotenvcrypt
+      elsif optional
+        return
       end
     end
+
+    # load environment as requested, with optional decryption
+    env = Environment.new(filename)
+    instrument('dotenv.load', :env => env) { override ? env.apply! : env.apply }
   end
 
-  # same as `load`, but raises Errno::ENOENT if any files don't exist
-  def load!(*filenames)
-    with(*filenames) do |f|
-      env = Environment.new(f)
-      instrument('dotenv.load', :env => env) { env.apply }
-    end
-  end
-
-  # same as `load`, but will override existing values in `ENV`
-  def overload(*filenames)
-    with(*filenames) do |f|
-      if File.exist?(f)
-        env = Environment.new(f)
-        instrument('dotenv.overload', :env => env) { env.apply! }
-      end
-    end
-  end
+  def load     *filenames; with(*filenames) {|f| process(f, true , false) }; end
+  def load!    *filenames; with(*filenames) {|f| process(f, false, false) }; end
+  def overload *filenames; with(*filenames) {|f| process(f, true , true ) }; end
 
   # Internal: Helper to expand list of filenames.
   #

--- a/lib/dotenv.rb
+++ b/lib/dotenv.rb
@@ -10,7 +10,7 @@ module Dotenv
 
     # determine filename, return if not found and optional
     if !File.exist?(filename)
-      if ENV.key?("DOTENVCRYPT") && File.exist?(dotenvcrypt = "#{filename}crypt")
+      if ENV.key?("DOTENVCRYPT") && File.exist?(dotenvcrypt = "#{filename}.crypt")
         filename = dotenvcrypt
       elsif optional
         return

--- a/lib/dotenv/environment.rb
+++ b/lib/dotenv/environment.rb
@@ -12,7 +12,35 @@ module Dotenv
     end
 
     def read
-      File.read(@filename)
+      if @filename =~ /crypt$/
+
+        # ==[ Method 1: Ruby methods to mimic openssl's quirky approach ]==
+        #
+        # require 'openssl'
+        #
+        # data = File.read(@filename).unpack('m').first
+        # pass = ENV['DOTENVCRYPT']
+        # salt = data.slice!(0,16)[8,8]
+        #
+        # k1 = OpenSSL::Digest::MD5.new(     pass + salt).digest
+        # k2 = OpenSSL::Digest::MD5.new(k1 + pass + salt).digest
+        # iv = OpenSSL::Digest::MD5.new(k2 + pass + salt).digest
+        #
+        # aes = OpenSSL::Cipher.new('aes-256-cbc').decrypt
+        # aes.key = k1 + k2
+        # aes.iv = iv
+        # aes.update(data) + aes.final
+
+        # ==[ Method 2: OpenSSL commands to encrypt and decrypt ]==
+        #
+        # openssl aes-256-cbc    -a -pass env:DOTENVCRYPT -in .env > .envcrypt
+        # openssl aes-256-cbc -d -a -pass env:DOTENVCRYPT -in .envcrypt
+
+        `openssl aes-256-cbc -d -a -pass env:DOTENVCRYPT -in "#{@filename}"`.chomp
+
+      else
+        File.read(@filename)
+      end
     end
 
     def apply

--- a/lib/dotenv/environment.rb
+++ b/lib/dotenv/environment.rb
@@ -33,7 +33,7 @@ module Dotenv
 
         # ==[ Method 2: OpenSSL commands to encrypt and decrypt ]==
         #
-        # openssl aes-256-cbc    -a -pass env:DOTENVCRYPT -in .env > .envcrypt
+        # openssl aes-256-cbc    -a -pass file:.envcryptkey -in .env > .envcrypt
         # openssl aes-256-cbc -d -a -pass env:DOTENVCRYPT -in .envcrypt
 
         `openssl aes-256-cbc -d -a -pass env:DOTENVCRYPT -in "#{@filename}"`.chomp

--- a/lib/dotenv/environment.rb
+++ b/lib/dotenv/environment.rb
@@ -12,7 +12,7 @@ module Dotenv
     end
 
     def read
-      if @filename =~ /crypt$/
+      if @filename =~ /\.crypt$/
 
         # ==[ Method 1: Ruby methods to mimic openssl's quirky approach ]==
         #

--- a/lib/dotenv/environment.rb
+++ b/lib/dotenv/environment.rb
@@ -33,8 +33,31 @@ module Dotenv
 
         # ==[ Method 2: OpenSSL commands to encrypt and decrypt ]==
         #
-        # openssl aes-256-cbc    -a -pass file:.envcryptkey -in .env > .envcrypt
-        # openssl aes-256-cbc -d -a -pass env:DOTENVCRYPT -in .envcrypt
+        # To encrypt files on your development machine, first store your key,
+        # also called a password, in a UNVERSIONED file called .encryptkey
+        #
+        # One option is to store a random 256-bit Base64-encoded value:
+        #
+        #   openssl rand -base64 32 -out .envcryptkey
+        #
+        # Another option is to just store your key directly:
+        #
+        #   echo "My_K3wLsEKr!t" > .envcryptkey
+        #
+        # Only the first line of .envcryptkey is used, so trailing newlines are ok.
+        #
+        # Then, on your development machine, encrypt with the following command:
+        #
+        #   openssl aes-256-cbc -a -pass file:.envcryptkey -in .env -out .envcrypt
+        #
+        # Verify the decrypted output on your development machine with:
+        #
+        #   openssl aes-256-cbc -d -a -pass file:.envcryptkey -in .envcrypt
+        #
+        # You can then store your encrypted .envcrypt file in your repo.
+        #
+        # In production, set the DOTENVCRYPT environment variable to the contents of
+        # your .envcryptkey file and files will be decrypted as follows:
 
         `openssl aes-256-cbc -d -a -pass env:DOTENVCRYPT -in "#{@filename}"`.chomp
 

--- a/lib/dotenv/environment.rb
+++ b/lib/dotenv/environment.rb
@@ -33,8 +33,9 @@ module Dotenv
 
         # ==[ Method 2: OpenSSL commands to encrypt and decrypt ]==
         #
-        # To encrypt files on your development machine, first store your key,
-        # also called a password, in a UNVERSIONED file called .encryptkey
+        # -- On your development machine --
+        #
+        # First, create an unversioned file that contains your key (password):
         #
         # One option is to store a random 256-bit Base64-encoded value:
         #
@@ -46,18 +47,20 @@ module Dotenv
         #
         # Only the first line of .envcryptkey is used, so trailing newlines are ok.
         #
-        # Then, on your development machine, encrypt with the following command:
+        # Second, encrypt your files using this key:
         #
         #   openssl aes-256-cbc -a -pass file:.envcryptkey -in .env -out .envcrypt
         #
-        # Verify the decrypted output on your development machine with:
+        # Third, verify the process with:
         #
         #   openssl aes-256-cbc -d -a -pass file:.envcryptkey -in .envcrypt
         #
-        # You can then store your encrypted .envcrypt file in your repo.
+        # Lastly, store your encrypted .envcrypt file in your repo.
         #
-        # In production, set the DOTENVCRYPT environment variable to the contents of
-        # your .envcryptkey file and files will be decrypted as follows:
+        # -- On your production machine --
+        #
+        # Simply set the DOTENVCRYPT environment variable to the contents of your
+        # .envcryptkey file and files will be automatically decrypted with:
 
         `openssl aes-256-cbc -d -a -pass env:DOTENVCRYPT -in "#{@filename}"`.chomp
 

--- a/lib/dotenv/environment.rb
+++ b/lib/dotenv/environment.rb
@@ -39,28 +39,28 @@ module Dotenv
         #
         # One option is to store a random 256-bit Base64-encoded value:
         #
-        #   openssl rand -base64 32 -out .envcryptkey
+        #   openssl rand -base64 32 -out .env.cryptkey
         #
         # Another option is to just store your key directly:
         #
-        #   echo "My_K3wLsEKr!t" > .envcryptkey
+        #   echo "My_K3wLsEKr!t" > .env.cryptkey
         #
-        # Only the first line of .envcryptkey is used, so trailing newlines are ok.
+        # Only the first line of .env.cryptkey is used, so trailing newlines are ok.
         #
         # Second, encrypt your files using this key:
         #
-        #   openssl aes-256-cbc -a -pass file:.envcryptkey -in .env -out .envcrypt
+        #   openssl aes-256-cbc -a -pass file:.env.cryptkey -in .env -out .env.crypt
         #
         # Third, verify the process with:
         #
-        #   openssl aes-256-cbc -d -a -pass file:.envcryptkey -in .envcrypt
+        #   openssl aes-256-cbc -d -a -pass file:.env.cryptkey -in .env.crypt
         #
-        # Lastly, store your encrypted .envcrypt file in your repo.
+        # Lastly, store your encrypted .env.crypt file in your repo.
         #
         # -- On your production machine --
         #
         # Simply set the DOTENVCRYPT environment variable to the contents of your
-        # .envcryptkey file and files will be automatically decrypted with:
+        # .env.cryptkey file and files will be automatically decrypted with:
 
         `openssl aes-256-cbc -d -a -pass env:DOTENVCRYPT -in "#{@filename}"`.chomp
 


### PR DESCRIPTION
The idea here is to allow for easy local development with files stored as clear text, but also to provide an easy way to encrypt files when pushing to a repo. In production, the presence of a DOTENVCRYPT environment variable and a file suffixed with "crypt" indicates the file is encrypted. If so, then the DOTENVCRYPT environment variable will be used to decrypt the file when it is loaded.

This is just an idea, not sure if there's much interest, but figured I'll push it up anyway.