### PR TITLE
Added WrappedEnv class convenience methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,42 @@ Whenever your application loads, these variables will be available in `ENV`:
 config.fog_directory  = ENV['S3_BUCKET']
 ```
 
+## WrappedEnv
+
+`ENV` is a simple hash containing all environment variables.  The
+`WrappedEnv` class adds a few convenience methods for accessing
+your environment variables.
+
+```ruby
+Dotenv.load
+
+# []
+WrappedEnv['MY_VAR'] # => 'abc'
+WrappedEnv['FAKE_VAR'] # => nil
+
+# fetch
+WrappedEnv.fetch('MY_VAR') # => 'abc'
+WrappedEnv.fetch('FAKE_VAR') # => KeyError: key not found "FAKE_VAR"
+
+# cast
+# ENV = { 'INT' => '1', 'BOOL' => 'true' }
+WrappedEnv.cast('INT') # => 1
+WrappedEnv.fetch('INT') # => '1'
+
+WrappedEnv.cast('BOOL') # => true
+
+WrappedEnv.cast('FAKE_VAR') # => nil
+WrappedEnv.cast!('FAKE_VAR') # => KeyError: key not found "FAKE_VAR"
+
+# override/reset (for temporary changes and testing)
+WrappedEnv.fetch('MY_VAR') # => 'abc'
+WrappedEnv.override('MY_VAR') # => 'def'
+WrappedEnv.fetch('MY_VAR') # => 'def'
+WrappedEnv.reset
+WrappedEnv.fetch('MY_VAR') # => 'abc'
+
+```
+
 ## Multiple Rails Environments
 
 dotenv was originally created to load configuration variables into `ENV` in *development*. There are typically better ways to manage configuration in production environments - such as `/etc/environment` managed by [Puppet](https://github.com/puppetlabs/puppet) or [Chef](https://github.com/opscode/chef), `heroku config`, etc.

--- a/lib/dotenv.rb
+++ b/lib/dotenv.rb
@@ -1,3 +1,4 @@
+require 'wrapped_env'
 require 'dotenv/parser'
 require 'dotenv/environment'
 

--- a/lib/wrapped_env.rb
+++ b/lib/wrapped_env.rb
@@ -1,0 +1,59 @@
+class WrappedEnv
+  class << self
+    def [](key)
+      overrides.key?(key) ? overrides[key] : ENV[key]
+    end
+
+    def fetch(key, &block)
+      return overrides[key] if overrides.key?(key)
+      ENV.fetch(key, &block)
+    end
+
+    def cast(key)
+      normalize(self[key])
+    end
+
+    def cast!(key, &block)
+      normalize(fetch(key, &block))
+    end
+
+    def override(hash)
+      hash.each_pair do |key, val|
+        overrides[key] = val
+      end
+    end
+
+    def reset
+      overrides.clear
+    end
+
+    private
+
+    def normalize(val)
+      case
+      when val === 'true'  then true
+      when val === 'false' then false
+      when val === ''      then nil
+      when try_int(val)    then val.to_i
+      when try_float(val)  then val.to_f
+      else val
+      end
+    end
+
+    def try_int(val)
+      Integer(val)
+    rescue ArgumentError
+      nil
+    end
+
+    def try_float(val)
+      Float(val)
+    rescue ArgumentError
+      nil
+    end
+
+    def overrides
+      @overrides ||= {}
+    end
+  end
+end

--- a/spec/wrapped_env_spec.rb
+++ b/spec/wrapped_env_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+require 'tempfile'
+def env(text)
+  file = Tempfile.new('dotenv')
+  file.write text
+  file.close
+  env = Dotenv::Environment.new(file.path)
+  file.unlink
+  env
+end
+
+describe WrappedEnv do
+  subject { described_class }
+
+  before { env("OPTION_A=1\nOPTION_B=2").apply }
+
+  describe 'fetch' do
+    it 'reads the correct value' do
+      expect(subject.fetch('OPTION_A')).to eq '1'
+    end
+
+    it 'raises an error' do
+      expect { subject.fetch('OPTION_C') }.to(
+        raise_error described_class::KeyError
+      )
+    end
+  end
+
+  describe 'override' do
+    it 'rewrites the value' do
+      subject.override('OPTION_A' => '3')
+      expect(subject['OPTION_A']).to eq '3'
+    end
+  end
+
+  describe 'reset' do
+    it 'goes back to the original value' do
+      subject.override('OPTION_A' => '3')
+      subject.reset
+      expect(subject['OPTION_A']).to eq '1'
+    end
+  end
+
+  describe 'cast' do
+    before { env("INT=1\nFLOAT=1.01\nBOOL=true\nBLANK=\nSTRING=abc").apply }
+
+    it 'casts common values' do
+      expect(subject.cast('INT')).to eq 1
+      expect(subject.cast('FLOAT')).to eq 1.01
+      expect(subject.cast('BOOL')).to eq true
+      expect(subject.cast('BLANK')).to eq nil
+      expect(subject.cast('STRING')).to eq 'abc'
+    end
+
+    describe 'error raising version' do
+      it 'raises an error' do
+        expect { subject.cast!('FAKE') }.to(
+          raise_error described_class::KeyError
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ended up implementing a class like this for work and figured it gave us decent value and might be a nice thing for other people to use.  We had a few main issues we wanted to solve:

Forgetting to set environment variables lead to bugs in our error tracker that weren't obviously caused by environment variables.  We started using `WrappedEnv.fetch` for all required values so anytime one wasn't set it would be completely obvious what was going wrong.

Testing the effects of specific changes to environment variables was difficult to do without affecting the rest of our test suite.  Hence we added `WrappedEnv.override(hash)` and `WrappedEnv.reset` to allow specific test cases to change values, giving more flexibility than a simple `.env.test`

One problem with `ENV` is that all values are strings so you have to manually cast them yourself.  This can bite you especially with boolean values as the string 'false' evaluates to true.  If you have a toggle variable you can use to turn off certain features which is initially true you might reference it as `ENV['MY_TOGGLE_VAR']` in your code.  Then say you'd like to toggle it off in production, your only option is to entirely remove it from the environment which can lead to confusion later about whether or not your code will run.  You cannot set it to blank or false because both of those will be turned into strings and evaluate to true.

Replacing your `ENV[key]` calls with `WrappedEnv.cast(key)` and any call to `ENV.fetch(key)` with `WrappedEnv.cast!(key)` solves this problem the majority of the time.

Open to any feedback on this.