### PR TITLE
Ignore nonexistent files

### DIFF
--- a/lib/dotenv.rb
+++ b/lib/dotenv.rb
@@ -8,7 +8,7 @@ module Dotenv
 
   def load(*filenames)
     with(*filenames) do |f|
-      if File.exist?(f)
+      ignoring_nonexistent_files do
         env = Environment.new(f)
         instrument('dotenv.load', :env => env) { env.apply }
       end
@@ -26,7 +26,7 @@ module Dotenv
   # same as `load`, but will override existing values in `ENV`
   def overload(*filenames)
     with(*filenames) do |f|
-      if File.exist?(f)
+      ignoring_nonexistent_files do
         env = Environment.new(f)
         instrument('dotenv.overload', :env => env) { env.apply! }
       end
@@ -50,5 +50,10 @@ module Dotenv
     else
       block.call
     end
+  end
+
+  def ignoring_nonexistent_files
+    yield
+  rescue Errno::ENOENT
   end
 end

--- a/spec/dotenv_spec.rb
+++ b/spec/dotenv_spec.rb
@@ -84,16 +84,28 @@ describe Dotenv do
   end
 
   describe 'overload' do
-    let(:env_files) { [fixture_path('plain.env')] }
     subject { Dotenv.overload(*env_files) }
     it_behaves_like 'load'
 
-    it 'overrides any existing ENV variables' do
-      ENV['OPTION_A'] = 'predefined'
+    context 'when loading a file containing already set variables' do
+      let(:env_files) { [fixture_path('plain.env')] }
 
-      subject
+      it 'overrides any existing ENV variables' do
+        ENV['OPTION_A'] = 'predefined'
 
-      expect(ENV['OPTION_A']).to eq('1')
+        subject
+
+        expect(ENV['OPTION_A']).to eq('1')
+      end
+    end
+
+    context 'when the file does not exist' do
+      let(:env_files) { ['.env_does_not_exist'] }
+
+      it 'fails silently' do
+        expect { subject }.not_to raise_error
+        expect(ENV.keys).to eq(@env_keys)
+      end
     end
   end
 


### PR DESCRIPTION
- Add `overload` test coverage for missing files.
- Ignore nonexistent file errors as they happen instead of trying to guard for them.
  Checking for file existence before reading is prone to race conditions where the file in question is removed in between checking for it and reading it. A more viable approach is to ignore the exception for when it does not exist.