### PR TITLE
Add save_env

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ SECRET_HASH="something-with-a-#-hash"
 
 Variable names may not contain the `#` symbol. Values can use the `#` if they are enclosed in quotes.
 
+### Accessing environment variables
+
+`SAFE_ENV` works like `ENV` except it will raise an error if the
+environment variable does not exists:
+
+```
+[1] pry(main)> SAFE_ENV['CITY_OF_ATLANTIS']
+RuntimeError: Environment variable CITY_OF_ATLANTIS is missing
+```
+
 ## Multiple Rails Environments
 
 dotenv was originally created to load configuration variables into `ENV` in *development*. There are typically better ways to manage configuration in production environments - such as `/etc/environment` managed by [Puppet](https://github.com/puppetlabs/puppet) or [Chef](https://github.com/opscode/chef), `heroku config`, etc.

--- a/dotenv.gemspec
+++ b/dotenv.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new "dotenv", Dotenv::VERSION do |gem|
     .split($OUTPUT_RECORD_SEPARATOR)
   gem.executables   = gem.files.grep(/^bin\//).map { |f| File.basename(f) }
 
+  gem.add_runtime_dependency "safe_env", "~> 0.1"
+
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "rubocop"

--- a/lib/dotenv.rb
+++ b/lib/dotenv.rb
@@ -1,5 +1,6 @@
 require "dotenv/parser"
 require "dotenv/environment"
+require "safe_env"
 
 # The top level Dotenv module. The entrypoint for the application logic.
 module Dotenv

--- a/spec/dotenv_spec.rb
+++ b/spec/dotenv_spec.rb
@@ -132,6 +132,26 @@ describe Dotenv do
     end
   end
 
+  describe "SAFE_ENV" do
+    before { ENV["APPLE"] = "apple" }
+
+    it "is defined" do
+      expect(defined?(SAFE_ENV)).to eql("constant")
+    end
+
+    it "gets env vars" do
+      expect(SAFE_ENV["APPLE"]).to eql(ENV["APPLE"])
+    end
+
+    it "raises an error when the var is not set" do
+      expect { SAFE_ENV["BANANA"] }
+        .to raise_error(RuntimeError)
+        .with_message("Environment variable BANANA is missing")
+    end
+
+    after { ENV.delete("APPLE") }
+  end
+
   def expand(path)
     File.expand_path path
   end


### PR DESCRIPTION
Missing environment variables usually cause problems. On many occasions an app will deploy OK even if critically important environment variables are not set, leading to headaches later on.

If an environment variable is required, but not set, it is advisable to fail as early as possible with a meaningful error message:

``` ruby
ENV.fetch('CITY_OF_ATLANTIS') { fail 'RuntimeError: Environment variable CITY_OF_ATLANTIS is missing' }
```

`safe_env` condenses this pattern. `safe_env` is a pretty 3 line snippet conceived by @opsb.

``` ruby
SAFE_ENV = Proc.new do |name|
  ENV[name].tap{ |value| raise "Environment variable #{name} is missing" unless value }
end
```

As you can see, `SAFE_ENV` works like `ENV` except it will raise an error if the
environment variable does not exists:

``` sh
[1] pry(main)> SAFE_ENV['CITY_OF_ATLANTIS']
RuntimeError: Environment variable CITY_OF_ATLANTIS is missing
```