### PR TITLE
Fix `rubocop` warnings

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -3,7 +3,7 @@ guard "bundler" do
 end
 
 guard "rspec", :cmd => "bundle exec rspec" do
-  watch(/^spec\/.+_spec\.rb$/)
-  watch(/^spec\/spec_helper.rb$/)    { "spec" }
-  watch(/^lib\/(.+)\.rb$/)           { |m| "spec/#{m[1]}_spec.rb" }
+  watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^spec/spec_helper.rb$}) { "spec" }
+  watch(%r{^lib/(.+)\.rb$})        { |m| "spec/#{m[1]}_spec.rb" }
 end

--- a/dotenv.gemspec
+++ b/dotenv.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new "dotenv", Dotenv::VERSION do |gem|
 
   gem.files         = `git ls-files README.md LICENSE lib bin | grep -v rails`
     .split($OUTPUT_RECORD_SEPARATOR)
-  gem.executables   = gem.files.grep(/^bin\//).map { |f| File.basename(f) }
+  gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"


### PR DESCRIPTION
Fixes `Use %r around regular expression`