### PR TITLE
simple generator

### DIFF
--- a/lib/dotenv/generator.rb
+++ b/lib/dotenv/generator.rb
@@ -1,0 +1,14 @@
+module Dotenv
+  # Generates a .env string from an env hash
+  class Generator
+    class << self
+      def call(hash, options = {})
+        hash.map do |k, v|
+          v = v.inspect
+          v.gsub!("$", "\\$") unless options[:unsafe]
+          "#{k}=#{v}"
+        end.join("\n") << "\n"
+      end
+    end
+  end
+end

--- a/spec/dotenv/cli_spec.rb
+++ b/spec/dotenv/cli_spec.rb
@@ -40,12 +40,14 @@ describe "dotenv binary" do
 
   # Capture output to $stdout and $stderr
   def capture_output(&_block)
-    original_stderr, original_stdout = $stderr, $stdout
+    original_stderr = $stderr
+    original_stdout = $stdout
     output = $stderr = $stdout = StringIO.new
 
     yield
 
-    $stderr, $stdout = original_stderr, original_stdout
+    $stderr = original_stderr
+    $stdout = original_stdout
     output.string
   end
 end

--- a/spec/dotenv/generator_spec.rb
+++ b/spec/dotenv/generator_spec.rb
@@ -1,0 +1,71 @@
+require "spec_helper"
+require "dotenv/generator"
+
+describe Dotenv::Generator do
+  def string(*args)
+    Dotenv::Generator.call(*args)
+  end
+
+  def env(string)
+    Dotenv::Parser.call(string)
+  end
+
+  def with_env(k, v)
+    old = ENV[k]
+    ENV[k] = v
+    yield
+  ensure
+    ENV[k] = old
+  end
+
+  def back_and_forth(env, string)
+    expect(string(env)).to eq(string)
+    expect(env(string)).to eq(env)
+  end
+
+  it "generates empty" do
+    back_and_forth({}, "\n")
+  end
+
+  it "generates simple values" do
+    back_and_forth({ "FOO" => "bar" }, "FOO=\"bar\"\n")
+  end
+
+  it "generates escaped double quotes" do
+    back_and_forth({ "FOO" => 'escaped"bar' }, "FOO=\"escaped\\\"bar\"\n")
+  end
+
+  it "generates empty values" do
+    back_and_forth({ "FOO" => "" }, "FOO=\"\"\n")
+  end
+
+  it "generates with escaped variables" do
+    back_and_forth({ "BAR" => "quote $FOOBAR" }, "BAR=\"quote \\$FOOBAR\"\n")
+  end
+
+  describe "unsafe" do
+    it "can generate with variables" do
+      with_env("FOOBAR", "111") do
+        string = string({ "BAR" => "quote $FOOBAR" }, :unsafe => true)
+        expect(string).to eq "BAR=\"quote $FOOBAR\"\n"
+        expect(env(string)).to eq "BAR" => "quote 111"
+      end
+    end
+
+    it "can prevent variables with escapes in unsafe mode" do
+      with_env("FOOBAR", "111") do
+        string = string({ "BAR" => "quote \\$FOOBAR" }, :unsafe => true)
+        expect(string).to eq "BAR=\"quote \\\\$FOOBAR\"\n"
+        expect(env(string)).to eq "BAR" => "quote $FOOBAR"
+      end
+    end
+  end
+
+  it "generates newlines in quoted strings" do
+    back_and_forth({ "FOO" => "bar\nbaz" }, "FOO=\"bar\\nbaz\"\n")
+  end
+
+  it "allows # in quoted value" do
+    back_and_forth({ "foo" => "bar#baz" }, "foo=\"bar#baz\"\n")
+  end
+end


### PR DESCRIPTION
@bkeepers 

I'm not sure what the expected $ expansion is supposed to be ... default should be safe I guess so escaping all the $ signs ... leaving unsafe option in to allow usecases that need them, can be avoided by using `\\$` ... 

I tried shellwords too, but was unable to parse them back in ... which the whole point of this generation logic is ...