### PR TITLE
Make dotenv-rails depend on rails 4 in production

### DIFF
--- a/dotenv-rails.gemspec
+++ b/dotenv-rails.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new "dotenv-rails", Dotenv::VERSION do |gem|
     .split($OUTPUT_RECORD_SEPARATOR) + ["README.md", "LICENSE"]
 
   gem.add_dependency "dotenv", Dotenv::VERSION
+  gem.add_dependency "railties", "~>4.0"
 
   gem.add_development_dependency "spring"
-  gem.add_development_dependency "railties", "~>4.0"
 end


### PR DESCRIPTION
As dotenv-rails doesn't currently depend on rails 4 apart from in development, my gemspecs are pulling it in automatically in rails 3 apps. Obviously, I will fix my own bundle, but it seems that dotenv-rails should be linked to rails itself as a full dependency.