### PR TITLE
supporting carriage return

### DIFF
--- a/lib/dotenv/parser.rb
+++ b/lib/dotenv/parser.rb
@@ -83,7 +83,7 @@ module Dotenv
     end
 
     def expand_newlines(value)
-      value.gsub('\n', "\n").gsub('\r',"\r")
+      value.gsub('\n', "\n").gsub('\r', "\r")
     end
 
     def variable_not_set?(line)

--- a/lib/dotenv/parser.rb
+++ b/lib/dotenv/parser.rb
@@ -41,7 +41,7 @@ module Dotenv
     end
 
     def call
-      @string.split("\n").each do |line|
+      @string.split(/[\n\r]+/).each do |line|
         parse_line(line)
       end
       @hash
@@ -83,7 +83,7 @@ module Dotenv
     end
 
     def expand_newlines(value)
-      value.gsub('\n', "\n")
+      value.gsub('\n', "\n").gsub('\r',"\r")
     end
 
     def variable_not_set?(line)

--- a/spec/dotenv/parser_spec.rb
+++ b/spec/dotenv/parser_spec.rb
@@ -144,6 +144,19 @@ export OH_NO_NOT_SET')
         .to eql("Quotes won't be a problem")
     end
 
+    it "supports carriage return" do
+      expect(env("FOO=bar\rbaz=fbb")).to eql("FOO" => "bar", "baz" => 'fbb')
+    end
+
+    it "supports carriage return combine with new line" do
+      expect(env("FOO=bar\r\nbaz=fbb")).to eql("FOO" => "bar", "baz" => 'fbb')
+    end
+
+    it "expands carriage return in quoted strings" do
+      expect(env('FOO="bar\rbaz"')).to eql("FOO" => "bar\rbaz")
+    end
+
+
     # This functionality is not supported on JRuby or Rubinius
     if (!defined?(RUBY_ENGINE) || RUBY_ENGINE != "jruby") &&
        !defined?(Rubinius)

--- a/spec/dotenv/parser_spec.rb
+++ b/spec/dotenv/parser_spec.rb
@@ -145,17 +145,16 @@ export OH_NO_NOT_SET')
     end
 
     it "supports carriage return" do
-      expect(env("FOO=bar\rbaz=fbb")).to eql("FOO" => "bar", "baz" => 'fbb')
+      expect(env("FOO=bar\rbaz=fbb")).to eql("FOO" => "bar", "baz" => "fbb")
     end
 
     it "supports carriage return combine with new line" do
-      expect(env("FOO=bar\r\nbaz=fbb")).to eql("FOO" => "bar", "baz" => 'fbb')
+      expect(env("FOO=bar\r\nbaz=fbb")).to eql("FOO" => "bar", "baz" => "fbb")
     end
 
     it "expands carriage return in quoted strings" do
       expect(env('FOO="bar\rbaz"')).to eql("FOO" => "bar\rbaz")
     end
-
 
     # This functionality is not supported on JRuby or Rubinius
     if (!defined?(RUBY_ENGINE) || RUBY_ENGINE != "jruby") &&


### PR DESCRIPTION
Carriage return is used in Mac OS.

Currently, if the .env file is like that (`\r` is the newline char in Mac):

    api_key=foo\r
    another_token=bar

then it would be parsed as: `api_key=foo\ranother_token=bar`

