### PR TITLE
Prepare for 2.0.2 release

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.0.2 - June 19, 2015
+
+* Support charriage returns in addition to newlines in .env ([#194](https://github.com/bkeepers/dotenv/pull/194))
+* Add runtime dependency on rails 4 for dotenv-rails ([#189](https://github.com/bkeepers/dotenv/pull/189))
+
+[Full Changelog](https://github.com/bkeepers/dotenv/compare/v2.0.1...v2.0.2)
+
 ## 2.0.1 - Apr 3, 2015
 
 * Fix for expansion of escaped variables ([#181](https://github.com/bkeepers/dotenv/pull/181))

--- a/lib/dotenv/version.rb
+++ b/lib/dotenv/version.rb
@@ -1,3 +1,3 @@
 module Dotenv
-  VERSION = "2.0.1"
+  VERSION = "2.0.2"
 end


### PR DESCRIPTION
* #194: supporting carriage return - @flyfy1
* #193: Add a Gitter chat badge to README.md - @gitter-badger
* #189: Make dotenv-rails depend on rails 4 in production - @Floppy
* #184: Feature/improve clarity of multiple env docs - @conorliv
* #182: Remove conflict marker - @teoljungberg
* #183: Fix `rubocop` warnings - @teoljungberg