### PR TITLE
escaped '$' characters at the end of a value are not unescaped

### DIFF
--- a/lib/dotenv/substitutions/variable.rb
+++ b/lib/dotenv/substitutions/variable.rb
@@ -10,11 +10,11 @@ module Dotenv
     module Variable
       class << self
         VARIABLE = /
-          (\\)?        # is it escaped with a backslash?
-          (\$)         # literal $
-          \{?          # allow brace wrapping
-          ([A-Z0-9_]+) # match the variable
-          \}?          # closing brace
+          (\\)?          # is it escaped with a backslash?
+          (\$)           # literal $
+          \{?            # allow brace wrapping
+          ($|[A-Z0-9_]+) # match the variable
+          \}?            # closing brace
         /xi
 
         def call(value, env)

--- a/spec/dotenv/parser_spec.rb
+++ b/spec/dotenv/parser_spec.rb
@@ -64,6 +64,10 @@ describe Dotenv::Parser do
       .to eql("FOO" => "test", "BAR" => "foo${FOO} test")
   end
 
+  it "escapes '$' characters at the end of a value" do
+    expect(env('FOO="\$bar\$"')).to eql("FOO" => "$bar$")
+  end
+
   it "parses yaml style options" do
     expect(env("OPTION_A: 1")).to eql("OPTION_A" => "1")
   end


### PR DESCRIPTION
If '$' is the last character within a double quoted string for a value, and the character is escaped with a backslash, it will not be properly unescaped. For example, if I have the following in a .env file:

FOO="bar\$"

The following will be injected into my environment:

ENV['FOO']
=> "bar\\$"

Where I would expect "bar$"

This patch fixes the issue and adds a test case.