### PR TITLE
Ensure Spring.application_root is defined as Rails.root

### DIFF
--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -7,7 +7,10 @@ begin
   require "spring/watcher"
   ActiveSupport::Notifications.subscribe(/^dotenv/) do |*args|
     event = ActiveSupport::Notifications::Event.new(*args)
-    Spring.watch event.payload[:env].filename if Rails.application
+    if Rails.application
+      Spring.application_root = Rails.root
+      Spring.watch event.payload[:env].filename 
+    end
   end
 rescue LoadError
   # Spring is not available


### PR DESCRIPTION
I have had issues with Dotenv when initializing a Rails app from a non-rails
root directory e.g.

`require File.dirname(__FILE__) + "/../../config/environment"`

because Spring.application_root was set to the path of file I was
executing in.

The stacktrace of the error:

```
Spring was unable to find your config/application.rb file. Your project
root was detected at

/home/deploy/app/releases/20150817220143/lib/daemons,
so spring looked for
/home/deploy/app/releases/20150817220143/lib/daemons/config/application.rb
but it doesn't exist. You can configure the root of your application by
setting Spring.application_root in config/spring.rb.
(Spring::MissingApplication)
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/spring-1.3.6/lib/spring/watcher.rb:24:in
`watcher'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/spring-1.3.6/lib/spring/watcher.rb:28:in
`watch'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/dotenv-rails-2.0.0/lib/dotenv/rails.rb:12:in
`block in <top (required)>'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/activesupport-3.2.20/lib/active_support/notifications/fanout.rb:47:in
`call'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/activesupport-3.2.20/lib/active_support/notifications/fanout.rb:47:in
`publish'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/activesupport-3.2.20/lib/active_support/notifications/fanout.rb:25:in
`block in publish'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/activesupport-3.2.20/lib/active_support/notifications/fanout.rb:25:in
`each'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/activesupport-3.2.20/lib/active_support/notifications/fanout.rb:25:in
`publish'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/activesupport-3.2.20/lib/active_support/notifications/instrumenter.rb:25:in
`instrument'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/activesupport-3.2.20/lib/active_support/notifications.rb:123:in
`instrument'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/dotenv-2.0.0/lib/dotenv.rb:52:in
`instrument'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/dotenv-2.0.0/lib/dotenv.rb:16:in
`block (2 levels) in load'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/dotenv-2.0.0/lib/dotenv.rb:59:in
`ignoring_nonexistent_files'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/dotenv-2.0.0/lib/dotenv.rb:14:in
`block in load'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/dotenv-2.0.0/lib/dotenv.rb:46:in
`call'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/dotenv-2.0.0/lib/dotenv.rb:46:in
`block in with'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/dotenv-2.0.0/lib/dotenv.rb:45:in
`each'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/dotenv-2.0.0/lib/dotenv.rb:45:in
`reduce'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/dotenv-2.0.0/lib/dotenv.rb:45:in
`with'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/dotenv-2.0.0/lib/dotenv.rb:13:in
`load'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/dotenv-rails-2.0.0/lib/dotenv/rails.rb:30:in
`load'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/dotenv-rails-2.0.0/lib/dotenv/rails.rb:47:in
`load'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/dotenv-rails-2.0.0/lib/dotenv/rails.rb:23:in
`block in <class:Railtie>'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/activesupport-3.2.20/lib/active_support/lazy_load_hooks.rb:34:in
`call'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/activesupport-3.2.20/lib/active_support/lazy_load_hooks.rb:34:in
`execute_hook'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/activesupport-3.2.20/lib/active_support/lazy_load_hooks.rb:43:in
`block in
run_load_hooks'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/activesupport-3.2.20/lib/active_support/lazy_load_hooks.rb:42:in
`each'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/activesupport-3.2.20/lib/active_support/lazy_load_hooks.rb:42:in
`run_load_hooks'
from
/home/deploy/app/shared/bundle/ruby/1.9.1/gems/railties-3.2.20/lib/rails/application.rb:67:in
`inherited'
from
/home/deploy/app/releases/20150817220143/config/application.rb:15
```

Setting Spring.application_root fixed the issue and seemed like a
sensible addition.