### PR TITLE
parser_spec: don't assume being run with `ruby`

### DIFF
--- a/spec/dotenv/parser_spec.rb
+++ b/spec/dotenv/parser_spec.rb
@@ -125,12 +125,14 @@ export OH_NO_NOT_SET')
   end
 
   if RUBY_VERSION > "1.8.7"
+    ruby = RbConfig::CONFIG["RUBY_INSTALL_NAME"]
+
     it "parses shell commands interpolated in $()" do
-      expect(env("ruby_v=$(ruby -v)")).to eql("ruby_v" => RUBY_DESCRIPTION)
+      expect(env("ruby_v=$(#{ruby} -v)")).to eql("ruby_v" => RUBY_DESCRIPTION)
     end
 
     it "allows balanced parentheses within interpolated shell commands" do
-      expect(env('ruby_v=$(echo "$(echo "$(echo "$(ruby -v)")")")'))
+      expect(env('ruby_v=$(echo "$(echo "$(echo "$(' + ruby + ' -v)")")")'))
         .to eql("ruby_v" => RUBY_DESCRIPTION)
     end
 


### PR DESCRIPTION
On Debian unstable there are two Ruby interpreters available during
transitions, and for QA purposes we always run tests during build for
all Ruby versions. When running under the one that is not the default,
the output of `ruby -v` will never match RUBY_DESCRIPTION.