### PR TITLE
Fix for #207, Some escaped '$' characters are not unescaped

### DIFF
--- a/lib/dotenv/substitutions/variable.rb
+++ b/lib/dotenv/substitutions/variable.rb
@@ -12,8 +12,9 @@ module Dotenv
         VARIABLE = /
           (\\)?        # is it escaped with a backslash?
           (\$)         # literal $
+          (?!\()       # shouldnt be followed by paranthesis
           \{?          # allow brace wrapping
-          ([A-Z0-9_]+) # match the variable
+          (?(1)[A-Z0-9_]*|([A-Z0-9_]+)) # if escaped, no need to match with alphanumericals
           \}?          # closing brace
         /xi
 

--- a/lib/dotenv/substitutions/variable.rb
+++ b/lib/dotenv/substitutions/variable.rb
@@ -10,12 +10,12 @@ module Dotenv
     module Variable
       class << self
         VARIABLE = /
-          (\\)?        # is it escaped with a backslash?
-          (\$)         # literal $
-          (?!\()       # shouldnt be followed by paranthesis
-          \{?          # allow brace wrapping
-          (?(1)[A-Z0-9_]*|([A-Z0-9_]+)) # if escaped, no need to match with alphanumericals
-          \}?          # closing brace
+          (\\)?         # is it escaped with a backslash?
+          (\$)          # literal $
+          (?!\()        # shouldnt be followed by paranthesis
+          \{?           # allow brace wrapping
+          (?(1)[A-Z0-9_]*|([A-Z0-9_]+)) # if escaped, no need to match with alpha nums
+          \}?           # closing brace
         /xi
 
         def call(value, env)

--- a/lib/dotenv/substitutions/variable.rb
+++ b/lib/dotenv/substitutions/variable.rb
@@ -14,7 +14,7 @@ module Dotenv
           (\$)          # literal $
           (?!\()        # shouldnt be followed by paranthesis
           \{?           # allow brace wrapping
-          (?(1)[A-Z0-9_]*|([A-Z0-9_]+)) # if escaped, no need to match with alpha nums
+          (?(1)[A-Z0-9_]*|([A-Z0-9_]+)) # if escaped, dont match alpha nums
           \}?           # closing brace
         /xi
 

--- a/lib/dotenv/substitutions/variable.rb
+++ b/lib/dotenv/substitutions/variable.rb
@@ -14,7 +14,7 @@ module Dotenv
           (\$)          # literal $
           (?!\()        # shouldnt be followed by paranthesis
           \{?           # allow brace wrapping
-          (?(1)[A-Z0-9_]*|([A-Z0-9_]+)) # if escaped, dont match alpha nums
+          ([A-Z0-9_]+)? # optional alpha nums
           \}?           # closing brace
         /xi
 
@@ -24,8 +24,10 @@ module Dotenv
 
             if match[1] == '\\'
               variable[1..-1]
-            else
+            elsif match[3]
               env.fetch(match[3]) { ENV[match[3]] }
+            else
+              variable
             end
           end
         end

--- a/spec/dotenv/parser_spec.rb
+++ b/spec/dotenv/parser_spec.rb
@@ -156,6 +156,12 @@ export OH_NO_NOT_SET')
       expect(env('FOO="bar\rbaz"')).to eql("FOO" => "bar\rbaz")
     end
 
+
+    it "escape $ properly when no alphabets/numbers/_  are followed by it" do
+      expect(env("FOO=\"bar\\$ \\$\\$\"")).to eql("FOO" => "bar$ $$")
+    end
+
+
     # This functionality is not supported on JRuby or Rubinius
     if (!defined?(RUBY_ENGINE) || RUBY_ENGINE != "jruby") &&
        !defined?(Rubinius)

--- a/spec/dotenv/parser_spec.rb
+++ b/spec/dotenv/parser_spec.rb
@@ -160,6 +160,11 @@ export OH_NO_NOT_SET')
       expect(env("FOO=\"bar\\$ \\$\\$\"")).to eql("FOO" => "bar$ $$")
     end
 
+    # echo bar $ -> prints bar $ in the shell
+    it "ignore $ when it is not escaped and no variable is followed by it" do
+      expect(env("FOO=\"bar $ \"")).to eql("FOO" => "bar $ ")
+    end
+
     # This functionality is not supported on JRuby or Rubinius
     if (!defined?(RUBY_ENGINE) || RUBY_ENGINE != "jruby") &&
        !defined?(Rubinius)

--- a/spec/dotenv/parser_spec.rb
+++ b/spec/dotenv/parser_spec.rb
@@ -156,11 +156,9 @@ export OH_NO_NOT_SET')
       expect(env('FOO="bar\rbaz"')).to eql("FOO" => "bar\rbaz")
     end
 
-
     it "escape $ properly when no alphabets/numbers/_  are followed by it" do
       expect(env("FOO=\"bar\\$ \\$\\$\"")).to eql("FOO" => "bar$ $$")
     end
-
 
     # This functionality is not supported on JRuby or Rubinius
     if (!defined?(RUBY_ENGINE) || RUBY_ENGINE != "jruby") &&


### PR DESCRIPTION
The issue was that the regex was not capturing $ which are not followed by alphanumericals. So, cases like "BAR\$" and "\$\$" were not handled. 
Made changes to take care of these.