### PR TITLE
fix issue #219: use `Dotenv.overload` method in `Railie#load`

### DIFF
--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -26,8 +26,8 @@ module Dotenv
     def load
       Dotenv.overload(
         root.join(".env"),
-        root.join(".env.local"),
-        root.join(".env.#{Rails.env}")
+        root.join(".env.#{Rails.env}"),
+        root.join(".env.local")
       )
     end
 

--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -24,10 +24,10 @@ module Dotenv
     # This will get called during the `before_configuration` callback, but you
     # can manually call `Dotenv::Railtie.load` if you needed it sooner.
     def load
-      Dotenv.load(
+      Dotenv.overload(
+        root.join(".env"),
         root.join(".env.local"),
-        root.join(".env.#{Rails.env}"),
-        root.join(".env")
+        root.join(".env.#{Rails.env}")
       )
     end
 

--- a/spec/dotenv/rails_spec.rb
+++ b/spec/dotenv/rails_spec.rb
@@ -52,9 +52,9 @@ describe Dotenv::Railtie do
 
     it "loads .env, .env.local, and .env.#{Rails.env}" do
       expect(Spring.watcher.items).to eql([
-        Rails.root.join(".env.local").to_s,
+        Rails.root.join(".env").to_s,
         Rails.root.join(".env.test").to_s,
-        Rails.root.join(".env").to_s
+        Rails.root.join(".env.local").to_s
       ])
     end
 


### PR DESCRIPTION
This is a fix for #219 

Turns out `rake` will trigger `before_configuration` hook twice, first with `Rails.env == development`, second with `Rails.env ==  test`. 

If we define same env var in both `.env.development` and `.env.test`, `Dotenv.load` will use the one defined in `.env.development`.

Change `load` method should fix this issue