### PR TITLE
allow up to rails 5.0

### DIFF
--- a/dotenv-rails.gemspec
+++ b/dotenv-rails.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new "dotenv-rails", Dotenv::VERSION do |gem|
     .split($OUTPUT_RECORD_SEPARATOR) + ["README.md", "LICENSE"]
 
   gem.add_dependency "dotenv", Dotenv::VERSION
-  gem.add_dependency "railties", "~>4.0"
+  gem.add_dependency "railties", ">= 4.0.0"
 
   gem.add_development_dependency "spring"
 end


### PR DESCRIPTION
Rails 5.0.0.beta1 came out. Relaxed the dependencies so this can be used with Rails 5.0.0.beta1.