### PR TITLE
treat old sh : like a no-op

### DIFF
--- a/lib/dotenv/parser.rb
+++ b/lib/dotenv/parser.rb
@@ -57,7 +57,7 @@ module Dotenv
         if variable_not_set?(line)
           fail FormatError, "Line #{line.inspect} has an unset variable"
         end
-      elsif line !~ /\A\s*(?:#.*)?\z/ # not comment or blank line
+      elsif line !~ /\A\s*(?:[#:].*)?\z/ # not comment, blank line, or noop
         fail FormatError, "Line #{line.inspect} doesn't match format"
       end
     end

--- a/spec/dotenv/parser_spec.rb
+++ b/spec/dotenv/parser_spec.rb
@@ -119,6 +119,10 @@ export OH_NO_NOT_SET')
     expect(env("\n\n\n # HERE GOES FOO \nfoo=bar")).to eql("foo" => "bar")
   end
 
+  it "ignores old bourne-shell command (now no-op)" do
+    expect(env("\n\n\n : HERE GOES FOO \nfoo=bar")).to eql("foo" => "bar")
+  end
+
   it "parses # in quoted values" do
     expect(env('foo="ba#r"')).to eql("foo" => "ba#r")
     expect(env("foo='ba#r'")).to eql("foo" => "ba#r")


### PR DESCRIPTION
This is a small change that tells Dotenv to treat `:` like `#`.  I think the very first shell required `:` before every command, but now it's treated as a no-op by sh, dash, bash, zsh, and probably other shells.  It's still useful in a very few situations (at least in bash), like so:

```
: ${FOO:=bar} # set FOO=bar if FOO is unset
```

That line would fail without `:`, because it doesn't actually run a command.

My use case: I want to source .env in bash and have .env source another file, .env.local, the same as `Dotenv.load('.env.local', '.env')`.  Example:

```
: [ -f .env.local ] && . .env.local
```

This patch simply causes Dotenv to ignore the line, while the shell will still execute it.  I'm not sure if this is the best way to do it.  I see that Dotenv can handle shell commands for values but I personally don't need that here.  Comments are welcome.
