### PR TITLE
Fix Rubocop offenses

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -3,7 +3,7 @@ guard "bundler" do
 end
 
 guard "rspec", :cmd => "bundle exec rspec" do
-  watch(/^spec\/.+_spec\.rb$/)
-  watch(/^spec\/spec_helper.rb$/) { "spec" }
-  watch(/^lib\/(.+)\.rb$/)        { |m| "spec/#{m[1]}_spec.rb" }
+  watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^spec/spec_helper.rb$}) { "spec" }
+  watch(%r{^lib/(.+)\.rb$})        { |m| "spec/#{m[1]}_spec.rb" }
 end

--- a/dotenv-rails.gemspec
+++ b/dotenv-rails.gemspec
@@ -7,8 +7,9 @@ Gem::Specification.new "dotenv-rails", Dotenv::VERSION do |gem|
   gem.description   = gem.summary = "Autoload dotenv in Rails."
   gem.homepage      = "https://github.com/bkeepers/dotenv"
   gem.license       = "MIT"
-  gem.files         = `git ls-files lib | grep rails`
-    .split($OUTPUT_RECORD_SEPARATOR) + ["README.md", "LICENSE"]
+  gem.files         = `git ls-files lib | grep rails`.split(
+    $OUTPUT_RECORD_SEPARATOR
+  ) + ["README.md", "LICENSE"]
 
   gem.add_dependency "dotenv", Dotenv::VERSION
   gem.add_dependency "railties", ">= 4.0", "< 5.1"

--- a/dotenv.gemspec
+++ b/dotenv.gemspec
@@ -8,9 +8,9 @@ Gem::Specification.new "dotenv", Dotenv::VERSION do |gem|
   gem.homepage      = "https://github.com/bkeepers/dotenv"
   gem.license       = "MIT"
 
-  gem.files         = `git ls-files README.md LICENSE lib bin | grep -v rails`
-    .split($OUTPUT_RECORD_SEPARATOR)
-  gem.executables = gem.files.grep(/^bin\//).map { |f| File.basename(f) }
+  gem_files         = `git ls-files README.md LICENSE lib bin | grep -v rails`
+  gem.files         = gem_files.split($OUTPUT_RECORD_SEPARATOR)
+  gem.executables = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"

--- a/lib/dotenv.rb
+++ b/lib/dotenv.rb
@@ -39,11 +39,11 @@ module Dotenv
   # Internal: Helper to expand list of filenames.
   #
   # Returns a hash of all the loaded environment variables.
-  def with(*filenames, &block)
+  def with(*filenames)
     filenames << ".env" if filenames.empty?
 
     filenames.reduce({}) do |hash, filename|
-      hash.merge! block.call(File.expand_path(filename)) || {}
+      hash.merge!(yield(File.expand_path(filename)) || {})
     end
   end
 
@@ -51,7 +51,7 @@ module Dotenv
     if instrumenter
       instrumenter.instrument(name, payload, &block)
     else
-      block.call
+      yield
     end
   end
 

--- a/lib/dotenv/environment.rb
+++ b/lib/dotenv/environment.rb
@@ -14,7 +14,7 @@ module Dotenv
     end
 
     def read
-      File.open(@filename, "rb:bom|utf-8") { |file| file.read }
+      File.open(@filename, "rb:bom|utf-8", &:read)
     end
 
     def apply

--- a/lib/dotenv/parser.rb
+++ b/lib/dotenv/parser.rb
@@ -55,10 +55,10 @@ module Dotenv
         @hash[key] = parse_value(value || "")
       elsif line.split.first == "export"
         if variable_not_set?(line)
-          fail FormatError, "Line #{line.inspect} has an unset variable"
+          raise FormatError, "Line #{line.inspect} has an unset variable"
         end
       elsif line !~ /\A\s*(?:#.*)?\z/ # not comment or blank line
-        fail FormatError, "Line #{line.inspect} doesn't match format"
+        raise FormatError, "Line #{line.inspect} doesn't match format"
       end
     end
 

--- a/lib/dotenv/version.rb
+++ b/lib/dotenv/version.rb
@@ -1,3 +1,3 @@
 module Dotenv
-  VERSION = "2.1.0"
+  VERSION = "2.1.0".freeze
 end

--- a/spec/dotenv/rails_spec.rb
+++ b/spec/dotenv/rails_spec.rb
@@ -51,11 +51,13 @@ describe Dotenv::Railtie do
     end
 
     it "loads .env, .env.local, and .env.#{Rails.env}" do
-      expect(Spring.watcher.items).to eql([
-        Rails.root.join(".env.local").to_s,
-        Rails.root.join(".env.test").to_s,
-        Rails.root.join(".env").to_s
-      ])
+      expect(Spring.watcher.items).to eql(
+        [
+          Rails.root.join(".env.local").to_s,
+          Rails.root.join(".env.test").to_s,
+          Rails.root.join(".env").to_s
+        ]
+      )
     end
 
     it "loads .env.local before .env" do

--- a/spec/dotenv_spec.rb
+++ b/spec/dotenv_spec.rb
@@ -141,7 +141,7 @@ describe Dotenv do
 
     it "fixture file has UTF-8 BOM" do
       contents = File.open(subject, "rb", &:read).force_encoding("UTF-8")
-      expect(contents).to start_with("\xEF\xBB\xBF")
+      expect(contents).to start_with("\xEF\xBB\xBF".force_encoding("UTF-8"))
     end
   end
 

--- a/spec/dotenv_spec.rb
+++ b/spec/dotenv_spec.rb
@@ -140,7 +140,7 @@ describe Dotenv do
     end
 
     it "fixture file has UTF-8 BOM" do
-      contents = File.open(subject, "rb") { |f| f.read }.force_encoding("UTF-8")
+      contents = File.open(subject, "rb", &:read).force_encoding("UTF-8")
       expect(contents).to start_with("\xEF\xBB\xBF")
     end
   end


### PR DESCRIPTION
Fix the following offenses.

```
$ bundle exec rubocop  
Inspecting 23 files
CC.C...CC.....C.C...CC.

Offenses:

dotenv-rails.gemspec:11:5: C: Align .split with git ls-files lib | grep rails on line 10.
    .split($OUTPUT_RECORD_SEPARATOR) + ["README.md", "LICENSE"]
    ^^^^^^
dotenv.gemspec:12:5: C: Align .split with git ls-files README.md LICENSE lib bin | grep -v rails on line 11.
    .split($OUTPUT_RECORD_SEPARATOR)
    ^^^^^^
dotenv.gemspec:13:36: C: Use %r around regular expression.
  gem.executables = gem.files.grep(/^bin\//).map { |f| File.basename(f) }
                                   ^^^^^^^^
Guardfile:6:9: C: Use %r around regular expression.
  watch(/^spec\/.+_spec\.rb$/)
        ^^^^^^^^^^^^^^^^^^^^^
Guardfile:7:9: C: Use %r around regular expression.
  watch(/^spec\/spec_helper.rb$/) { "spec" }
        ^^^^^^^^^^^^^^^^^^^^^^^^
Guardfile:8:9: C: Use %r around regular expression.
  watch(/^lib\/(.+)\.rb$/)        { |m| "spec/#{m[1]}_spec.rb" }
        ^^^^^^^^^^^^^^^^^
lib/dotenv/environment.rb:17:44: C: Pass &:read as an argument to open instead of a block.
      File.open(@filename, "rb:bom|utf-8") { |file| file.read }
                                           ^^^^^^^^^^^^^^^^^^^^
lib/dotenv/parser.rb:58:11: C: Always use raise to signal exceptions.
          fail FormatError, "Line #{line.inspect} has an unset variable"
          ^^^^
lib/dotenv/parser.rb:61:9: C: Always use raise to signal exceptions.
        fail FormatError, "Line #{line.inspect} doesn't match format"
        ^^^^
lib/dotenv/version.rb:2:13: C: Freeze mutable objects assigned to constants.
  VERSION = "2.1.0"
            ^^^^^^^
lib/dotenv.rb:46:19: C: Use yield instead of block.call.
      hash.merge! block.call(File.expand_path(filename)) || {}
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/dotenv.rb:54:7: C: Use yield instead of block.call.
      block.call
      ^^^^^^^^^^
spec/dotenv/rails_spec.rb:55:9: C: Use 2 spaces for indentation in an array, relative to the first position after the preceding left parenthesis.
        Rails.root.join(".env.local").to_s,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/dotenv/rails_spec.rb:58:7: C: Indent the right bracket the same as the first position after the preceding left parenthesis.
      ])
      ^
spec/dotenv_spec.rb:143:43: C: Pass &:read as an argument to open instead of a block.
      contents = File.open(subject, "rb") { |f| f.read }.force_encoding("UTF-8")
                                          ^^^^^^^^^^^^^^

23 files inspected, 15 offenses detected
```

Thanks.