### PR TITLE
Lock rubocop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,3 @@ notifications:
 
 script:
   - bundle exec rake
-  - bundle exec rubocop

--- a/Rakefile
+++ b/Rakefile
@@ -28,4 +28,7 @@ RSpec::Core::RakeTask.new(:spec) do |t|
   t.verbose = false
 end
 
-task :default => :spec
+require "rubocop/rake_task"
+RuboCop::RakeTask.new
+
+task :default => [:spec, :rubocop]

--- a/dotenv.gemspec
+++ b/dotenv.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new "dotenv", Dotenv::VERSION do |gem|
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"
-  gem.add_development_dependency "rubocop"
+  gem.add_development_dependency "rubocop", "~>0.37.2"
 end


### PR DESCRIPTION
This locks the version of rubocop to prevent offenses from randomly cropping up. /cc #239 #230 #183 