### PR TITLE
Fix for rspec rake tasks initializing in development

### DIFF
--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -8,8 +8,9 @@ require "dotenv"
 # but rspec does not include the same hacks.
 #
 # See https://github.com/bkeepers/dotenv/issues/219
-if defined?(Rake.application) && Rake.application.top_level_tasks.grep(/^spec(:|$)/).any?
-  Rails.env = ENV['RAILS_ENV'] ||= 'test'
+if defined?(Rake.application)
+  is_running_specs = Rake.application.top_level_tasks.grep(/^spec(:|$)/).any?
+  Rails.env = ENV["RAILS_ENV"] ||= "test" if is_running_specs
 end
 
 Dotenv.instrumenter = ActiveSupport::Notifications

--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -1,5 +1,17 @@
 require "dotenv"
 
+# Fix for rspec rake tasks loading in development
+#
+# Dotenv loads environment variables when the Rails application is initialized.
+# When running `rake`, the Rails application is initialized in development.
+# Rails includes some hacks to set `RAILS_ENV=test` when running `rake test`,
+# but rspec does not include the same hacks.
+#
+# See https://github.com/bkeepers/dotenv/issues/219
+if defined?(Rake.application) && Rake.application.top_level_tasks.grep(/^spec(:|$)/).any?
+  Rails.env = ENV['RAILS_ENV'] ||= 'test'
+end
+
 Dotenv.instrumenter = ActiveSupport::Notifications
 
 # Watch all loaded env files with Spring


### PR DESCRIPTION
This fixes #219, which causes Rails apps to always be initialized in development when being loaded from rake, by adding a hack that sets `RAILS_ENV=test` when `rake spec` is being run.

Rails [already includes a hack](https://github.com/rails/rails/blob/56ca2061df83a307943a0ffdfe6f5f4ed5846cf7/railties/lib/rails/test_unit/railtie.rb#L3-L5) like this, which will set `RAILS_ENV=test` when running `rake test`. This hack used to be loaded when requiring `rails/all`, but https://github.com/rails/rails/pull/10256 moved to to only be loaded when requiring `test_unit/railtie`. So, deally, rspec would copy this behavior when loading the [rspec railtie](https://github.com/rspec/rspec-rails/blob/master/lib/rspec-rails.rb).

I need to figure out a way to test this. I would appreciate any ideas for how to do that easily. The only thing I can think is to add a couple bare-bones Rails apps to the test suite that have different dependencies configured. :disappointed: 

/cc @bitherder
