### PR TITLE
Allow failures for jruby-head until next release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ rvm:
   - jruby-19mode
   - jruby-head
 
+matrix:
+  allow_failures:
+    - rvm: jruby-head
+
 sudo: false
 
 bundler_args: --without=guard


### PR DESCRIPTION
#233 is caused by a bug the latest release in jruby. It's fixed upstream, but currently causing the build to fail. This updates travis to allow failures on `jruby-head` for now.