### PR TITLE
Fix load error when using Spring w/ custom config

### DIFF
--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -4,7 +4,7 @@ Dotenv.instrumenter = ActiveSupport::Notifications
 
 # Watch all loaded env files with Spring
 begin
-  require "spring/watcher"
+  require "spring/commands"
   ActiveSupport::Notifications.subscribe(/^dotenv/) do |*args|
     event = ActiveSupport::Notifications::Event.new(*args)
     Spring.watch event.payload[:env].filename if Rails.application


### PR DESCRIPTION
I'm currently working a project that is a [Rails engine](http://guides.rubyonrails.org/engines.html)

When I add `dotenv-rails` to my `Gemfile`, and try to run a command, say: `bundle exec rspec spec`, this error occurs:

```
{gem-path}/spring-1.6.4/lib/spring/configuration.rb:31:in `application_root_path':
Spring was unable to find your config/application.rb file.
Your project root was detected at {project-root}, so spring looked
for {project-root}/config/application.rb but it doesn't exist.

You can configure the root of your application by
setting Spring.application_root in config/spring.rb. (Spring::MissingApplication)
  from {gem-path}/spring-1.6.4/lib/spring/watcher.rb:24:in `watcher`
```

The error is saying that Spring can't find my `application_root`. This is odd, because [Spring allows for custom configuration](https://github.com/rails/spring#configuration), such as specifying where to find the root directory of your Rails application.

This is especially helpful when working with a Rails Engine, and the root of the application lives [within the dummy app](https://github.com/rails/spring#configuration).

In my project, Spring's `application_root` is configured via a `./config.spring.rb` file.

[In `lib/dotenv/rails`](https://github.com/bkeepers/dotenv/blob/8fa4c4d8051f834f3d75eaa48cb1adb6994300c6/lib/dotenv/rails.rb#L7) Spring's `watcher` file was being included, but that watcher file doesn't trigger the loading of custom Spring configurations.

Those includes take place in Spring's [`commands`](https://github.com/rails/spring/blob/2f88ab31297b79b3b5cf0059c2beb944052277f7/lib/spring/commands.rb) file.

Specifically:

- [Loading of `.spring.rb` files](https://github.com/rails/spring/blob/2f88ab31297b79b3b5cf0059c2beb944052277f7/lib/spring/commands.rb#L26-L29)
- [Loading of `./config.spring.rb` files](https://github.com/rails/spring/blob/2f88ab31297b79b3b5cf0059c2beb944052277f7/lib/spring/commands.rb#L48-L49)

Changed `lib/dotenv/rails` to instead include `spring/commands` (which in itself includes the `watcher` file). This allows for Spring to preload any configurations before `dotenv-rails` uses the `Spring.watch`
command.