### PR TITLE
allow loading env-specific locals for Rails

### DIFF
--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -25,6 +25,7 @@ module Dotenv
     # can manually call `Dotenv::Railtie.load` if you needed it sooner.
     def load
       Dotenv.load(
+        root.join(".env.#{Rails.env}.local"),
         root.join(".env.local"),
         root.join(".env.#{Rails.env}"),
         root.join(".env")


### PR DESCRIPTION
This feture costs 1 line of code, but give more freedom to users
