### PR TITLE
Fix a failure spec in ruby 2.4.0dev

### DIFF
--- a/lib/dotenv/parser.rb
+++ b/lib/dotenv/parser.rb
@@ -9,7 +9,7 @@ module Dotenv
   # exporting of variables.
   class Parser
     @substitutions =
-      Substitutions.constants.map { |const| Substitutions.const_get(const) }
+      [Dotenv::Substitutions::Variable, Dotenv::Substitutions::Command]
 
     LINE = /
       \A


### PR DESCRIPTION
Fix the following failure spec.

```sh
$ ruby -v
ruby 2.4.0dev (2016-03-23 trunk 54236) [x86_64-darwin13]
$ bundle exec rake spec
.............................................F..........................

Failures:

  1) Dotenv::Parser substitutes shell variables within interpolated shell commands
     Failure/Error:
       expect(env(%(VAR1=var1\ninterp=$(echo "VAR1 is $VAR1")))["interp"])
         .to eql("VAR1 is var1")
     
       expected: "VAR1 is var1"
            got: "VAR1 is "
     
       (compared using eql?)
     # ./spec/dotenv/parser_spec.rb:172:in `block (2 levels) in <top (required)>'

Finished in 0.16655 seconds (files took 0.62432 seconds to load)
72 examples, 1 failure

Failed examples:

rspec ./spec/dotenv/parser_spec.rb:171 # Dotenv::Parser substitutes shell variables within interpolated shell commands

```

## Cause

Module#constants method makes NO guarantees about the order in which the constants are yielded. Then order of the constants has changed in ruby 2.4.0dev.

### Ruby 2.3.0 and earlier

```ruby
Substitutions.constants.map { |const| Substitutions.const_get(const) }
#=> [Dotenv::Substitutions::Variable, Dotenv::Substitutions::Command]
```

### ruby 2.4.0dev (Edge)

```ruby
Substitutions.constants.map { |const| Substitutions.const_get(const) }
#=> [Dotenv::Substitutions::Command, Dotenv::Substitutions::Variable]
```

Thanks.