### PR TITLE
Add dotenv/load shortcut file

### DIFF
--- a/lib/dotenv/load.rb
+++ b/lib/dotenv/load.rb
@@ -1,0 +1,2 @@
+require "dotenv"
+Dotenv.load


### PR DESCRIPTION
So it can be used as:

``` ruby
require "dotenv/load"
```

as a shortcut for:

``` ruby
require "dotenv"
Dotenv.load
```

In similar fashion to Bundler's `bundler/setup` which requires bundler then calls `Bundler.setup`.
