### PR TITLE
Fix deprecation warning

### DIFF
--- a/dotenv.gemspec
+++ b/dotenv.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new "dotenv", Dotenv::VERSION do |gem|
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"
-  gem.add_development_dependency "rubocop", "~>0.37.2"
+  gem.add_development_dependency "rubocop", "~>0.40.0"
 end


### PR DESCRIPTION
This pull request fix the following deprecation warning.

```sh
% bundle exec rake
[DEPRECATION] `last_comment` is deprecated.  Please use `last_description` instead.
```

This warning was resolved by upgrade to [Rubocop >= 0.38.0](https://github.com/bbatsov/rubocop/commit/88a200e59e10868450ceb4316ffc600d9a09b95c). Therefore, Rubocop has been changed to latest version 0.40.0 in this PR.