### PR TITLE
Also load .env.#{Rails.env}.local

### DIFF
--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -26,6 +26,7 @@ module Dotenv
     def load
       Dotenv.load(
         root.join(".env.local"),
+        root.join(".env.#{Rails.env}.local"),
         root.join(".env.#{Rails.env}"),
         root.join(".env")
       )

--- a/spec/dotenv/rails_spec.rb
+++ b/spec/dotenv/rails_spec.rb
@@ -54,6 +54,7 @@ describe Dotenv::Railtie do
       expect(Spring.watcher.items).to eql(
         [
           Rails.root.join(".env.local").to_s,
+          Rails.root.join(".env.test.local").to_s,
           Rails.root.join(".env.test").to_s,
           Rails.root.join(".env").to_s
         ]

--- a/spec/fixtures/.env.test.local
+++ b/spec/fixtures/.env.test.local
@@ -1,0 +1,3 @@
+FROM_RAILS_ENV=.env.test
+FROM_LOCAL=true
+DOTENV=local


### PR DESCRIPTION
This allows customization of specific Rails environments, instead of having
.env.local override values for _all_ Rails environments, which is not always
desirable.
