### PR TITLE
Added support to rails overload variables

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ Style/Documentation:
 
 Style/FileName:
   Exclude:
+    - 'lib/dotenv/rails-overload.rb'
     - 'lib/dotenv/rails-now.rb'
     - 'lib/dotenv-rails.rb'
 

--- a/lib/dotenv/rails-overload.rb
+++ b/lib/dotenv/rails-overload.rb
@@ -1,0 +1,8 @@
+# If want you use dotenv to override variable already set in the system
+# then list `dotenv-rails` in the `Gemfile` and require `dotenv/rails-overload`
+#
+#     gem "dotenv-rails", :require => "dotenv/rails-overload"
+#
+
+require "dotenv/rails"
+Dotenv::Railtie.overload

--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -31,6 +31,14 @@ module Dotenv
       )
     end
 
+    def overload
+      Dotenv.overload(
+        root.join(".env"),
+        root.join(".env.#{Rails.env}"),
+        root.join(".env.local")
+      )
+    end
+
     # Internal: `Rails.root` is nil in Rails 4.1 before the application is
     # initialized, so this falls back to the `RAILS_ROOT` environment variable,
     # or the current working directory.


### PR DESCRIPTION
The use case is when running rails with something like foreman or heroku local.
Both cases will preload the `.env` and will make dotenv ignore every override
in files like `.env.local` or `.env.#{Rails.env}`

With this PR if you load `dotenv-rails` with a `dotnev/rails-overload` require
it will overload the file in the inverse order achieving the desired result.
