### PR TITLE
Make Load Order as a standalone subsetion [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,11 @@ However, some find dotenv to be a convenient way to configure Rails applications
 
 You can also use `.env.local` for local overrides.
 
-If you use this gem to handle env vars for multiple Rails environments (development, test, production, etc.), please note that env vars that are general to all environments should be stored in `.env`. Then, environment specific env vars should be stored in `.env.<that environment's name>`. When you load a certain environment, dotenv will first load general env vars from `.env`, then load environment specific env vars from `.env.<current environment>`. Variables defined in `.env.<current environment>` will override any values set in `.env` or already defined in the environment.
+If you use this gem to handle env vars for multiple Rails environments (development, test, production, etc.), please note that env vars that are general to all environments should be stored in `.env`. Then, environment specific env vars should be stored in `.env.<that environment's name>`.
+
+### .env* Files Load Order
+
+When you load a certain environment, dotenv will first load general env vars from `.env`, then load environment specific env vars from `.env.<current environment>`. Variables defined in `.env.<current environment>` will override any values set in `.env` or already defined in the environment. Finally loads the `.env.local` if presents.
 
 ## Should I commit my .env file?
 


### PR DESCRIPTION
Hi!

I am explaining the load order to someone and I think make the files load order as a standalone section is easier to share to someone.

Note I added one sentence in this Pull Request:

```
Finally loads the `.env.local` if presents.
```

Thanks!

[Preview The New Section](https://github.com/JuanitoFatas/dotenv/blob/69c8345f0d3716ad9398c398825d816ccbd39f3f/README.md#env-files-load-order).
