### PR TITLE
Reorder to make the load method available

### DIFF
--- a/dotenv-rails.gemspec
+++ b/dotenv-rails.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new "dotenv-rails", Dotenv::VERSION do |gem|
   ) + ["README.md", "LICENSE"]
 
   gem.add_dependency "dotenv", Dotenv::VERSION
-  gem.add_dependency "railties", ">= 4.0", "< 5.1"
+  gem.add_dependency "railties", ">= 3.2", "< 5.1"
 
   gem.add_development_dependency "spring"
 end

--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -41,7 +41,7 @@ module Dotenv
     def self.load
       instance.load
     end
-    
+
     config.before_configuration { load }
   end
 end

--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -17,8 +17,6 @@ module Dotenv
   # Dotenv Railtie for using Dotenv to load environment from a file into
   # Rails applications
   class Railtie < Rails::Railtie
-    config.before_configuration { load }
-
     # Public: Load dotenv
     #
     # This will get called during the `before_configuration` callback, but you
@@ -43,5 +41,7 @@ module Dotenv
     def self.load
       instance.load
     end
+    
+    config.before_configuration { load }
   end
 end


### PR DESCRIPTION
We are getting the following error when trying to use `require "dotenv/rails-now"`

> /Users/mikaelhenriksson/.rvm/gems/ruby-2.1.8/gems/activesupport-3.2.22.6/lib/active_support/dependencies.rb:243:in `load': wrong number of arguments (0 for 1..2) (ArgumentError)
>	from /Users/mikaelhenriksson/.rvm/gems/ruby-2.1.8/gems/dotenv-rails-2.0.1/lib/dotenv/rails.rb:20:in `block in <class:Railtie>'

Reordering the file so that the methods are defined before using them fixes this problem. Our codebase is from 2005 so I am sure it could be fixed in other ways but this is verified to fix our problem.

**Note 1:** The errors on CI doesn't seem to be related to my changes.
**Note 2:** This works for us on a rails 3.2 project