### PR TITLE
Allow local per env

### DIFF
--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -25,6 +25,7 @@ module Dotenv
     # can manually call `Dotenv::Railtie.load` if you needed it sooner.
     def load
       Dotenv.load(
+        root.join(".env.#{Rails.env}.local"),
         root.join(".env.local"),
         root.join(".env.#{Rails.env}"),
         root.join(".env")

--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -25,7 +25,6 @@ module Dotenv
       Dotenv.load(
         root.join(".env.#{Rails.env}.local"),
         root.join(".env.local"),
-        root.join(".env.#{Rails.env}.local"),
         root.join(".env.#{Rails.env}"),
         root.join(".env")
       )

--- a/spec/dotenv/rails_spec.rb
+++ b/spec/dotenv/rails_spec.rb
@@ -53,8 +53,8 @@ describe Dotenv::Railtie do
     it "loads .env, .env.local, and .env.#{Rails.env}" do
       expect(Spring.watcher.items).to eql(
         [
-          Rails.root.join(".env.local").to_s,
           Rails.root.join(".env.test.local").to_s,
+          Rails.root.join(".env.local").to_s,
           Rails.root.join(".env.test").to_s,
           Rails.root.join(".env").to_s
         ]


### PR DESCRIPTION
This pulls in changes from both #249 and #257 to support `.env.#{Rails.env}.local`. I'm not crazy about this change, but enough people have asked for it that I'll concede (but you can't make me document it…yet :trollface:).