### PR TITLE
Fix a build error on Travis CI by using latest RubyGems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ matrix:
     - rvm: rbx-2
     - rvm: jruby-head
 
+before_install:
+  - gem update --remote bundler
+  - gem update --system
+
 sudo: false
 
 bundler_args: --without=guard

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ rvm:
   - 2.2.6
   - 2.1.10
   - 2.0.0
-  - 1.9.3
   - rbx-2
-  - jruby-19mode
   - jruby-head
 
 matrix:


### PR DESCRIPTION
Fix a following build error on Travis CI.

https://travis-ci.org/bkeepers/dotenv/jobs/194667067

```sh
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    can't modify frozen String

Gem files will remain installed in
/home/travis/.rvm/gems/ruby-2.4.0/gems/rainbow-2.2.1 for inspection.
Results logged to
/home/travis/.rvm/gems/ruby-2.4.0/extensions/x86_64-linux/2.4.0/rainbow-2.2.1/gem_make.out

An error occurred while installing rainbow (2.2.1), and Bundler cannot
continue.
Make sure that `gem install rainbow -v '2.2.1'` succeeds before bundling.
```

This PR solves the problem by using the latest RubyGems.

cf. https://github.com/sickill/rainbow/issues/48

Thanks.
