### PR TITLE
Remove jruby and rbx builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,6 @@ rvm:
   - 2.2.6
   - 2.1.10
   - 2.0.0
-  - rbx-2
-  - jruby-head
-
-matrix:
-  allow_failures:
-    - rvm: rbx-2
-    - rvm: jruby-head
 
 before_install:
   - gem update --remote bundler


### PR DESCRIPTION
They've been failing for a while and in the `allowed_failures`. The jruby build takes significantly longer than the others, so this just removes them entirely.