### PR TITLE
Update ruby hash syntax

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,7 @@ Style/FileName:
     - 'lib/dotenv-rails.rb'
 
 Style/HashSyntax:
-  EnforcedStyle: 'hash_rockets'
+  EnforcedStyle: 'ruby19'
 
 Style/StringLiterals:
   EnforcedStyle: 'double_quotes'

--- a/Changelog.md
+++ b/Changelog.md
@@ -58,7 +58,7 @@
 
 * add `dotenv/rails-now`, which can be required in the `Gemfile` to immediately load dotenv.
 
-        gem 'dotenv-rails', :require => 'dotenv/rails-now'
+        gem 'dotenv-rails', require: 'dotenv/rails-now'
         gem 'gem-that-requires-env-variables'
 
 [Full Changelog](https://github.com/bkeepers/dotenv/compare/v1.0.1...v1.0.2)

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
-gemspec :name => "dotenv"
-gemspec :name => "dotenv-rails"
+gemspec name: "dotenv"
+gemspec name: "dotenv-rails"
 
 group :guard do
   gem "guard-rspec"

--- a/Guardfile
+++ b/Guardfile
@@ -2,7 +2,7 @@ guard "bundler" do
   watch("Gemfile")
 end
 
-guard "rspec", :cmd => "bundle exec rspec" do
+guard "rspec", cmd: "bundle exec rspec" do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^spec/spec_helper.rb$}) { "spec" }
   watch(%r{^lib/(.+)\.rb$})        { |m| "spec/#{m[1]}_spec.rb" }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ But it is not always practical to set environment variables on development machi
 Add this line to the top of your application's Gemfile:
 
 ```ruby
-gem 'dotenv-rails', :groups => [:development, :test]
+gem 'dotenv-rails', groups: [:development, :test]
 ```
 
 And then execute:
@@ -40,7 +40,7 @@ HOSTNAME = ENV['HOSTNAME']
 If you use gems that require environment variables to be set before they are loaded, then list `dotenv-rails` in the `Gemfile` before those other gems and require `dotenv/rails-now`.
 
 ```ruby
-gem 'dotenv-rails', :require => 'dotenv/rails-now'
+gem 'dotenv-rails', require: 'dotenv/rails-now'
 gem 'gem-that-requires-env-variables'
 ```
 
@@ -80,7 +80,7 @@ To ensure `.env` is loaded in rake, load the tasks:
 ```ruby
 require 'dotenv/tasks'
 
-task :mytask => :dotenv do
+task mytask: :dotenv do
     # things that require .env
 end
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@
 require "bundler/gem_helper"
 
 namespace "dotenv" do
-  Bundler::GemHelper.install_tasks :name => "dotenv"
+  Bundler::GemHelper.install_tasks name: "dotenv"
 end
 
 namespace "dotenv-rails" do
@@ -13,12 +13,12 @@ namespace "dotenv-rails" do
     def tag_version; end # noop
   end
 
-  DotenvRailsGemHelper.install_tasks :name => "dotenv-rails"
+  DotenvRailsGemHelper.install_tasks name: "dotenv-rails"
 end
 
-task :build => ["dotenv:build", "dotenv-rails:build"]
-task :install => ["dotenv:install", "dotenv-rails:install"]
-task :release => ["dotenv:release", "dotenv-rails:release"]
+task build: ["dotenv:build", "dotenv-rails:build"]
+task install: ["dotenv:install", "dotenv-rails:install"]
+task release: ["dotenv:release", "dotenv-rails:release"]
 
 require "rspec/core/rake_task"
 
@@ -31,4 +31,4 @@ end
 require "rubocop/rake_task"
 RuboCop::RakeTask.new
 
-task :default => [:spec, :rubocop]
+task default: [:spec, :rubocop]

--- a/lib/dotenv.rb
+++ b/lib/dotenv.rb
@@ -13,7 +13,7 @@ module Dotenv
     with(*filenames) do |f|
       ignoring_nonexistent_files do
         env = Environment.new(f)
-        instrument("dotenv.load", :env => env) { env.apply }
+        instrument("dotenv.load", env: env) { env.apply }
       end
     end
   end
@@ -22,7 +22,7 @@ module Dotenv
   def load!(*filenames)
     with(*filenames) do |f|
       env = Environment.new(f)
-      instrument("dotenv.load", :env => env) { env.apply }
+      instrument("dotenv.load", env: env) { env.apply }
     end
   end
 
@@ -31,7 +31,7 @@ module Dotenv
     with(*filenames) do |f|
       ignoring_nonexistent_files do
         env = Environment.new(f)
-        instrument("dotenv.overload", :env => env) { env.apply! }
+        instrument("dotenv.overload", env: env) { env.apply! }
       end
     end
   end

--- a/lib/dotenv/rails-now.rb
+++ b/lib/dotenv/rails-now.rb
@@ -2,7 +2,7 @@
 # loaded, then list `dotenv-rails` in the `Gemfile` before those other gems and
 # require `dotenv/rails-now`.
 #
-#     gem "dotenv-rails", :require => "dotenv/rails-now"
+#     gem "dotenv-rails", require: "dotenv/rails-now"
 #     gem "gem-that-requires-env-variables"
 #
 

--- a/lib/dotenv/tasks.rb
+++ b/lib/dotenv/tasks.rb
@@ -4,4 +4,4 @@ task :dotenv do
   Dotenv.load
 end
 
-task :environment => :dotenv
+task environment: :dotenv

--- a/spec/dotenv_spec.rb
+++ b/spec/dotenv_spec.rb
@@ -11,7 +11,7 @@ describe Dotenv do
 
       it "defaults to .env" do
         expect(Dotenv::Environment).to receive(:new).with(expand(".env"))
-          .and_return(double(:apply => {}, :apply! => {}))
+          .and_return(double(apply: {}, apply!: {}))
         subject
       end
     end
@@ -23,7 +23,7 @@ describe Dotenv do
         expected = expand("~/.env")
         allow(File).to receive(:exist?) { |arg| arg == expected }
         expect(Dotenv::Environment).to receive(:new).with(expected)
-          .and_return(double(:apply => {}, :apply! => {}))
+          .and_return(double(apply: {}, apply!: {}))
         subject
       end
     end
@@ -111,7 +111,7 @@ describe Dotenv do
   end
 
   describe "with an instrumenter" do
-    let(:instrumenter) { double("instrumenter", :instrument => {}) }
+    let(:instrumenter) { double("instrumenter", instrument: {}) }
     before { Dotenv.instrumenter = instrumenter }
     after { Dotenv.instrumenter = nil }
 


### PR DESCRIPTION
I saw this all over the project the :old => syntax, so I replaced
everything (with a script) with the new: syntax

```bash
$ find . -name \*.rb -exec perl -p -i -e 's/([^:]):(\w+)\s*=>/\1\2:/g' {} \;
```
Found that [here](http://effectif.com/ruby/update-your-project-for-ruby-19-hash-syntax)

EDIT:
Whoops, okay didn't noticed that you got rubocop so I updated the rubocop.yml and rerun rubocop using `rubocop -a`.