### PR TITLE
Skip over lines that don't set an envvars

### DIFF
--- a/lib/dotenv/parser.rb
+++ b/lib/dotenv/parser.rb
@@ -59,8 +59,6 @@ module Dotenv
         if variable_not_set?(line)
           raise FormatError, "Line #{line.inspect} has an unset variable"
         end
-      elsif line !~ /\A\s*(?:#.*)?\z/ # not comment or blank line
-        raise FormatError, "Line #{line.inspect} doesn't match format"
       end
     end
 

--- a/spec/dotenv/parser_spec.rb
+++ b/spec/dotenv/parser_spec.rb
@@ -114,8 +114,8 @@ export OH_NO_NOT_SET')
     expect(env("foo=bar ")).to eql("foo" => "bar") # not 'bar '
   end
 
-  it "throws an error if line format is incorrect" do
-    expect { env("lol$wut") }.to raise_error(Dotenv::FormatError)
+  it "ignores lines that are not variable assignments" do
+    expect(env("lol$wut")).to eql({})
   end
 
   it "ignores empty lines" do


### PR DESCRIPTION
This makes dotenv play better with .env files that
do more than just set variables, e.g. defining aliases
and functions

closes #285