### PR TITLE
Specify existing behaviour for parsing empty values.

### DIFF
--- a/spec/dotenv/parser_spec.rb
+++ b/spec/dotenv/parser_spec.rb
@@ -145,6 +145,10 @@ export OH_NO_NOT_SET')
     expect(env("foo='ba#r'  ")).to eql("foo" => "ba#r")
   end
 
+  it "parses empty values" do
+    expect(env("foo=")).to eql("foo" => "")
+  end
+
   if RUBY_VERSION > "1.8.7"
     it "parses shell commands interpolated in $()" do
       expect(env("echo=$(echo hello)")).to eql("echo" => "hello")


### PR DESCRIPTION
This is related to an issue opened on the go implementation (see https://github.com/joho/godotenv/issues/26) where I'm trying to maintain file level compatibility with this lib.

I had a user relying on this functionality but no test documenting it. I tested dotenv & bash and discovered it was consistent but unspecified/undocumented here. Adding a test to move the behaviour up from accidental to on purpose 😄 