### PR TITLE
Load ".enc" files encrypted with Sekrets

### DIFF
--- a/lib/dotenv/environment.rb
+++ b/lib/dotenv/environment.rb
@@ -14,7 +14,15 @@ module Dotenv
     end
 
     def read
-      File.open(@filename, "rb:bom|utf-8", &:read)
+      if defined? Sekrets
+        if @filename =~ /\.enc$/
+          Sekrets.read(@filename) || raise(Errno::ENOENT)
+        else
+          File.open(@filename, "rb:bom|utf-8", &:read)
+        end
+      else
+        File.open(@filename, "rb:bom|utf-8", &:read)
+      end
     end
 
     def apply

--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -56,6 +56,14 @@ module Dotenv
     private
 
     def dotenv_files
+      if defined? Sekrets
+        clear_files.map { |f| ["#{f}.enc", f] }.flatten
+      else
+        clear_files
+      end
+    end
+
+    def clear_files
       [
         root.join(".env.#{Rails.env}.local"),
         (root.join(".env.local") unless Rails.env.test?),


### PR DESCRIPTION
Dotenv is great, I've been using it for long in all my projects. But one feature I miss is the possibility to version-control `.env` files: as you may know saving configuration secrets/passwords inside git repos is a big no-no... as long as they're clear. We avoid to commit even `.env.development` files for security reasons. 

Saving encrypted configuration would vastly help our distributed teams, we would just need to pass along the decryption key instead of a whole config file which, more often than not, is not complete and up to current development status, because each developer ends up having/receiving/spreading a different version of the file. That's messy.

So I started playing with both `dotenv` and the `sekrets` gem to make them work together. I can now load encrypted dotenv files also with ".enc" extension, which can now be safely commited into the repository. 

Of course the code is quite rough, I am not even sure that dotenv is the right place to add this enhancement (maybe a new `dotenv-sekrets` gem?) so I am submitting the PR just to start a conversation about the encryption topic. 