### PR TITLE
Rescue from spring require error

### DIFF
--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -22,7 +22,7 @@ begin
     event = ActiveSupport::Notifications::Event.new(*args)
     Spring.watch event.payload[:env].filename if Rails.application
   end
-rescue LoadError
+rescue LoadError, ArgumentError
   # Spring is not available
 end
 


### PR DESCRIPTION
Resolves an issue reported in #297 when loading `spring/commands` calls `File.expand_path`, but the `HOME` environment variable is not set

This occurs when deploying to AWS Elastic Beanstalk, but potentially other environments as well.