### PR TITLE
Rescue from bundler require error

### DIFF
--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -22,7 +22,7 @@ begin
     event = ActiveSupport::Notifications::Event.new(*args)
     Spring.watch event.payload[:env].filename if Rails.application
   end
-rescue LoadError
+rescue LoadError, ArgumentError
   # Spring is not available
 end
 


### PR DESCRIPTION
Resolves an issue where spring tries to `File.expand_path` and the
`$HOME` variable is not set.

This was identified as an issue with AWS Elastic Beanstalk deployments