### PR TITLE
backward compatible to v2.2 as parser

### DIFF
--- a/lib/dotenv/parser.rb
+++ b/lib/dotenv/parser.rb
@@ -30,12 +30,12 @@ module Dotenv
     class << self
       attr_reader :substitutions
 
-      def call(string, is_load)
+      def call(string, is_load = false)
         new(string, is_load).call
       end
     end
 
-    def initialize(string, is_load)
+    def initialize(string, is_load = false)
       @string = string
       @hash = {}
       @is_load = is_load


### PR DESCRIPTION
#338 
Version 2.3 is not backward compatible with features such as `parser`

Therefore, since we made backwards compatibility for `parser`, I would like to confirm it

