### PR TITLE
Backwards Compatible Dotenv::Environment

### DIFF
--- a/lib/dotenv/environment.rb
+++ b/lib/dotenv/environment.rb
@@ -4,12 +4,12 @@ module Dotenv
   class Environment < Hash
     attr_reader :filename
 
-    def initialize(filename, is_load)
+    def initialize(filename, is_load = false)
       @filename = filename
       load(is_load)
     end
 
-    def load(is_load)
+    def load(is_load = false)
       update Parser.call(read, is_load)
     end
 


### PR DESCRIPTION
* Commit 7f82f73 introduced a backwards-incompatible change in the current API with respect to `Dotenv::Environment#intialize` by changing the method signature.
* Make the new parameter default to false to retain backwards compatibility.
* Similar changes were made for `Dotenv::Parser` in #338.

SEE: https://github.com/bkeepers/dotenv/pull/323
SEE: https://github.com/bkeepers/dotenv/pull/338