### PR TITLE
Double-escaped newlines and carriage returns should not be expanded

### DIFF
--- a/lib/dotenv/parser.rb
+++ b/lib/dotenv/parser.rb
@@ -88,7 +88,7 @@ module Dotenv
     end
 
     def expand_newlines(value)
-      value.gsub('\n', "\n").gsub('\r', "\r")
+      value.gsub(/(?<=[^\\])\\n/, "\n").gsub(/(?<=[^\\])\\r/, "\r")
     end
 
     def variable_not_set?(line)

--- a/spec/dotenv/parser_spec.rb
+++ b/spec/dotenv/parser_spec.rb
@@ -262,6 +262,10 @@ one more line")
       expect(env("FOO=\"bar $ \"")).to eql("FOO" => "bar $ ")
     end
 
+    it "should not expand double-escaped newlines" do
+      expect(env('FOO="\\\\n"')).to eql("FOO" => "\\n")
+    end
+
     # This functionality is not supported on JRuby or Rubinius
     if (!defined?(RUBY_ENGINE) || RUBY_ENGINE != "jruby") &&
        !defined?(Rubinius)


### PR DESCRIPTION
It was impossible to set an environment variable with value `'\\n'`.