### PR TITLE
Add Dotenv.parse method

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,16 @@ Dotenv.require_keys("SERVICE_APP_ID", "SERVICE_KEY", "SERVICE_SECRET")
 
 If any of the configuration keys above are not set, your application will raise an error during initialization. This method is preferred because it prevents runtime errors in a production application due to improper configuration.
 
+### Parsing
+
+To parse a list of env files for programmatic inspection of without modifying the ENV:
+
+```ruby
+Dotenv.parse(".env.local", ".env")
+# => {'S3_BUCKET' => 'YOURS3BUCKET', 'SECRET_KEY' => 'YOURSECRETKEYGOESHERE', ...}
+```
+
+This method returns a hash of the ENV var name/value pairs.
 
 ## Frequently Answered Questions
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ If any of the configuration keys above are not set, your application will raise 
 
 ### Parsing
 
-To parse a list of env files for programmatic inspection of without modifying the ENV:
+To parse a list of env files for programmatic inspection without modifying the ENV:
 
 ```ruby
 Dotenv.parse(".env.local", ".env")

--- a/lib/dotenv.rb
+++ b/lib/dotenv.rb
@@ -45,6 +45,15 @@ module Dotenv
     end
   end
 
+  # returns a hash of parsed key/value pairs but does not modify ENV
+  def parse(*filenames)
+    with(*filenames) do |f|
+      ignoring_nonexistent_files do
+        Environment.new(f, false)
+      end
+    end
+  end
+
   # Internal: Helper to expand list of filenames.
   #
   # Returns a hash of all the loaded environment variables.


### PR DESCRIPTION
Opening the PR for discussion around a new feature request. 

Exposes parsing logic as a public API to allow programmatic inspection of .env files without modifying `ENV`.

One such use case is for automated application setup to create/read/modify `.env` files prior to running the application for the first time. I found the need to dive into `Dotenv` internals to accomplish such a task while debugging installation scripts on a recent project and thought it would be useful to avoid relying on internal details.