### PR TITLE
Automate Rubygems Releases with Actions

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,30 @@
+workflow "Publish Gems" {
+  on = "push"
+  resolves = [
+    "Release dotenv",
+    "Release dotenv-rails",
+  ]
+}
+
+action "Tag Filter" {
+  uses = "actions/bin/filter@master"
+  args = "tag v*"
+}
+
+action "Release dotenv" {
+  uses = "cadwallion/publish-rubygems-action@master"
+  needs = ["Tag Filter"]
+  secrets = ["GITHUB_TOKEN", "RUBYGEMS_API_KEY"]
+  env = {
+    RELEASE_COMMAND = "rake dotenv:release"
+  }
+}
+
+action "Release dotenv-rails" {
+  uses = "cadwallion/publish-rubygems-action@master"
+  needs = ["Tag Filter"]
+  secrets = ["GITHUB_TOKEN", "RUBYGEMS_API_KEY"]
+  env = {
+    RELEASE_COMMAND = "rake dotenv-rails:release"
+  }
+}

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,19 +1,13 @@
 workflow "Publish Gems" {
-  on = "push"
   resolves = [
     "Release dotenv",
     "Release dotenv-rails",
   ]
-}
-
-action "Tag Filter" {
-  uses = "actions/bin/filter@master"
-  args = "tag v*"
+  on = "release"
 }
 
 action "Release dotenv" {
   uses = "cadwallion/publish-rubygems-action@master"
-  needs = ["Tag Filter"]
   secrets = ["GITHUB_TOKEN", "RUBYGEMS_API_KEY"]
   env = {
     RELEASE_COMMAND = "rake dotenv:release"
@@ -22,7 +16,6 @@ action "Release dotenv" {
 
 action "Release dotenv-rails" {
   uses = "cadwallion/publish-rubygems-action@master"
-  needs = ["Tag Filter"]
   secrets = ["GITHUB_TOKEN", "RUBYGEMS_API_KEY"]
   env = {
     RELEASE_COMMAND = "rake dotenv-rails:release"


### PR DESCRIPTION
This adds a GitHub Actions workflow for code pushes.  I created a [Custom Action](https://github.com/cadwallion/publish-rubygems-action) that handles triggering release commands.  If a tag is pushed with a version, both the dotenv and dotenv-rails gems will be published to Rubygems.org.  Note: since Actions only supports 'push' events in the beta, you have to tag and specifically push the tag, instead of using `git push --tags` for this to work.

# New Release Process

1. Bump the version, Commit
2. `git tag vX.Y.Z`
3. `git push origin vX.Y.Z`
4. Workflow will detect the push event was on a version tag, trigger release

Completes #367 

//cc @joelvh 