### PR TITLE
Expose Overload to Rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Dotenv::Railtie.load
 HOSTNAME = ENV['HOSTNAME']
 ```
 
+If you want to override existing environmental variables. Use ``Dotenv::Railtie.overload``
+
+
 If you use gems that require environment variables to be set before they are loaded, then list `dotenv-rails` in the `Gemfile` before those other gems and require `dotenv/rails-now`.
 
 ```ruby

--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -40,6 +40,7 @@ module Dotenv
 
     # Public: overload dotenv
     #
+    # same as `load`, but will override existing values in `ENV`
     def overload
       Dotenv.overload(*dotenv_files)
     end
@@ -57,13 +58,11 @@ module Dotenv
       instance.load
     end
 
-    # Same as load. Except will overload ENV variables.
+    # same as `load`, but will override existing values in `ENV`
     def self.overload
       self.instance.overload
     end
    
-
-
     config.before_configuration { load }
 
     private

--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -38,6 +38,12 @@ module Dotenv
       Dotenv.load(*dotenv_files)
     end
 
+    # Public: overload dotenv
+    #
+    def overload
+      Dotenv.overload(*dotenv_files)
+    end
+
     # Internal: `Rails.root` is nil in Rails 4.1 before the application is
     # initialized, so this falls back to the `RAILS_ROOT` environment variable,
     # or the current working directory.
@@ -50,6 +56,13 @@ module Dotenv
     def self.load
       instance.load
     end
+
+    # Same as load. Except will overload ENV variables.
+    def self.overload
+      self.instance.overload
+    end
+   
+
 
     config.before_configuration { load }
 


### PR DESCRIPTION
## Expose Dotenv override to Rails

### Allowing user to override existing environmental variables is handy.

### Existing
``Dotenv::Railtie.load``
 * **Does NOT** overwrite environmental variables. *i.e.* ``ENV[x] ||="NEW VAR"``


### NEW Functionality
``Dotenv::Railtie.overload``
  * **WILL** overwrite environmental variables. *i.e.* ``ENV[x] ="NEW VAR"``
