### PR TITLE
Clean up the option parser

### DIFF
--- a/lib/dotenv/cli.rb
+++ b/lib/dotenv/cli.rb
@@ -14,7 +14,7 @@ module Dotenv
     end
 
     def run
-      parse_argv! @argv
+      parse_argv!(@argv)
 
       begin
         Dotenv.load!(*@filenames)
@@ -30,7 +30,7 @@ module Dotenv
     def parse_argv!(argv)
       parser = create_option_parser
       add_options(parser)
-      parser.order! argv
+      parser.order!(argv)
 
       @filenames
     end

--- a/lib/dotenv/cli.rb
+++ b/lib/dotenv/cli.rb
@@ -6,23 +6,22 @@ module Dotenv
   # The CLI is a class responsible of handling all the command line interface
   # logic.
   class CLI
-    attr_reader :argv, :exec_args, :parser_args, :filenames
+    attr_reader :argv, :filenames
 
     def initialize(argv = [])
       @argv = argv.dup
       @filenames = []
-      @flag_matchers = []
     end
 
     def run
-      parse_argv!(@argv)
+      parse_argv! @argv
 
       begin
         Dotenv.load!(*@filenames)
       rescue Errno::ENOENT => e
         abort e.message
       else
-        exec(*@exec_args) unless @exec_args.empty?
+        exec(*@argv) unless @argv.empty?
       end
     end
 
@@ -30,56 +29,36 @@ module Dotenv
 
     def parse_argv!(argv)
       parser = create_option_parser
-      add_options(parser, @flag_matchers)
-      @parser_args, @exec_args = split_argv(argv.join(" "), @flag_matchers)
-      parser.parse! @parser_args
+      add_options(parser)
+      parser.order! argv
 
       @filenames
     end
 
-    def add_options(parser, flag_matchers)
-      add_files_option(parser, flag_matchers)
-      add_help_option(parser, flag_matchers)
-      add_version_option(parser, flag_matchers)
+    def add_options(parser)
+      add_files_option(parser)
+      add_help_option(parser)
+      add_version_option(parser)
     end
 
-    def add_files_option(parser, flag_matchers)
-      flag_matchers.push("-f \\S+")
+    def add_files_option(parser)
       parser.on("-f FILES", Array, "List of env files to parse") do |list|
         @filenames = list
       end
     end
 
-    def add_help_option(parser, flag_matchers)
-      flag_matchers.push("-h", "--help")
+    def add_help_option(parser)
       parser.on("-h", "--help", "Display help") do
         puts parser
         exit
       end
     end
 
-    def add_version_option(parser, flag_matchers)
-      flag_matchers.push("-v", "--version")
+    def add_version_option(parser)
       parser.on("-v", "--version", "Show version") do
         puts "dotenv #{Dotenv::VERSION}"
         exit
       end
-    end
-
-    # Detect dotenv flags vs executable args so we can parse properly and still
-    # take advantage of OptionParser for dotenv flags
-    def split_argv(arg_string, matchers)
-      matcher     = /^((?:#{matchers.join("|")})\s?)?(.+)?$/
-      data        = matcher.match(arg_string)
-      dotenv_args = []
-      exec_args   = []
-
-      unless data.nil?
-        dotenv_args = (!data[1].nil? ? data[1].split(" ") : [])
-        exec_args   = (!data[2].nil? ? data[2].split(" ") : [])
-      end
-
-      [dotenv_args, exec_args]
     end
 
     def create_option_parser

--- a/spec/dotenv/cli_spec.rb
+++ b/spec/dotenv/cli_spec.rb
@@ -43,7 +43,7 @@ describe "dotenv binary" do
     cli.send(:parse_argv!, cli.argv)
 
     expect(cli.filenames).to eql(["plain.env"])
-    expect(cli.exec_args).to eql(["foo", "--switch"])
+    expect(cli.argv).to eql(["foo", "--switch"])
   end
 
   it "does not consume dotenv flags from subcommand" do
@@ -51,7 +51,15 @@ describe "dotenv binary" do
     cli.send(:parse_argv!, cli.argv)
 
     expect(cli.filenames).to eql([])
-    expect(cli.exec_args).to eql(["foo", "-f", "something"])
+    expect(cli.argv).to eql(["foo", "-f", "something"])
+  end
+
+  it "does not mess with quoted args" do
+    cli = Dotenv::CLI.new(["foo something"])
+    cli.send(:parse_argv!, cli.argv)
+
+    expect(cli.filenames).to eql([])
+    expect(cli.argv).to eql(["foo something"])
   end
 
   # Capture output to $stdout and $stderr


### PR DESCRIPTION
This removes the regular expression logic and splitting out of the parser_args vs exec_args in favor of using OptionParser.order! which will not complain about unknown flags because order will stop at the first unknown argument.

This is a dramatic improvement to the CLI code clarity.
 
Closes #381 

Thanks to @bensherman for pairing up to better understand what was going on under the hood, and finding the .order! method. 

/cc @walro 