### PR TITLE
fix for parallel spec tasks initializing in development

### DIFF
--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -9,7 +9,7 @@ require "dotenv"
 #
 # See https://github.com/bkeepers/dotenv/issues/219
 if defined?(Rake.application)
-  is_running_specs = Rake.application.top_level_tasks.grep(/^spec(:|$)/).any?
+  is_running_specs = Rake.application.top_level_tasks.grep(/^(parallel:spec|spec(:|$))/).any?
   Rails.env = ENV["RAILS_ENV"] ||= "test" if is_running_specs
 end
 

--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -9,8 +9,9 @@ require "dotenv"
 #
 # See https://github.com/bkeepers/dotenv/issues/219
 if defined?(Rake.application)
-  is_running_specs = Rake.application.top_level_tasks.grep(/^(parallel:spec|spec(:|$))/).any?
-  Rails.env = ENV["RAILS_ENV"] ||= "test" if is_running_specs
+  if Rake.application.top_level_tasks.grep(/^(parallel:spec|spec(:|$))/).any?
+    Rails.env = ENV["RAILS_ENV"] ||= "test"
+  end
 end
 
 Dotenv.instrumenter = ActiveSupport::Notifications


### PR DESCRIPTION
along the lines of https://github.com/bkeepers/dotenv/pull/241, this will fix tasks for running parallel specs using the https://github.com/grosser/parallel_tests gem. (this will also match the `parallel:spec[...]` syntax.)