### PR TITLE
Fixes load order issue.

### DIFF
--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -51,8 +51,6 @@ module Dotenv
       instance.load
     end
 
-    config.before_configuration { load }
-
     private
 
     def dotenv_files
@@ -63,5 +61,7 @@ module Dotenv
         root.join(".env")
       ].compact
     end
+
+    config.before_configuration { load }
   end
 end


### PR DESCRIPTION
If `Rails` is already loaded by the time `dotenv` is loaded, the
configuration block is executed immediately, prior to the rest of the
`Railtie` class being finished. Fixes https://github.com/bkeepers/dotenv/issues/297