### PR TITLE
Fix `NoMethodError` when using dotenv without Rails.

### DIFF
--- a/lib/dotenv/cli.rb
+++ b/lib/dotenv/cli.rb
@@ -22,7 +22,7 @@ module Dotenv
       rescue Errno::ENOENT => e
         abort e.message
       else
-        exec(*@argv) if @argv.present?
+        exec(*@argv) unless @argv.empty?
       end
     end
 


### PR DESCRIPTION
This reverts commit 00e14aa186917b557a6ccb2c08ea89e56f3faad1.

Reason: The pure Ruby doesn't have `Array#present?`. So this cause `NoMethodError` when using dotenv without Rails.

```
$ dotenv -t .env
Traceback (most recent call last):
	3: from /bin/dotenv:23:in `<main>'
	2: from /bin/dotenv:23:in `load'
	1: from /lib/ruby/gems/2.5.0/gems/dotenv-2.7.3/bin/dotenv:4:in `<top (required)>'
/lib/ruby/gems/2.5.0/gems/dotenv-2.7.3/lib/dotenv/cli.rb:25:in `run': undefined method `present?' for []:Array (NoMethodError)
Did you mean?  prepend
```