### PR TITLE
Adds specs and fix for \s after separator

### DIFF
--- a/lib/dotenv/parser.rb
+++ b/lib/dotenv/parser.rb
@@ -12,21 +12,21 @@ module Dotenv
       [Dotenv::Substitutions::Variable, Dotenv::Substitutions::Command]
 
     LINE = /
-      (?:^|\A)           # beginning of line
-      \s*                # leading whitespace
-      (?:export\s+)?     # optional export
-      ([\w\.]+)          # key
-      (?:\s*=\s*?|:\s+?) # separator
-      (                  # optional value begin
-        '(?:\\'|[^'])*'  #   single quoted value
-        |                #   or
-        "(?:\\"|[^"])*"  #   double quoted value
-        |                #   or
-        [^\#\r\n]+       #   unquoted value
-      )?                 # value end
-      \s*                # trailing whitespace
-      (?:\#.*)?          # optional comment
-      (?:$|\z)           # end of line
+      (?:^|\A)              # beginning of line
+      \s*                   # leading whitespace
+      (?:export\s+)?        # optional export
+      ([\w\.]+)             # key
+      (?:\s*=\s*?|:\s+?)    # separator
+      (                     # optional value begin
+        \s*'(?:\\'|[^'])*'  #   single quoted value
+        |                   #   or
+        \s*"(?:\\"|[^"])*"  #   double quoted value
+        |                   #   or
+        [^\#\r\n]+          #   unquoted value
+      )?                    # value end
+      \s*                   # trailing whitespace
+      (?:\#.*)?             # optional comment
+      (?:$|\z)              # end of line
     /x
 
     class << self

--- a/spec/dotenv/parser_spec.rb
+++ b/spec/dotenv/parser_spec.rb
@@ -9,6 +9,10 @@ describe Dotenv::Parser do
     expect(env("FOO=bar")).to eql("FOO" => "bar")
   end
 
+  it "parses unquoted values with spaces after seperator" do
+    expect(env("FOO= bar")).to eql("FOO" => "bar")
+  end
+
   it "parses values with spaces around equal sign" do
     expect(env("FOO =bar")).to eql("FOO" => "bar")
     expect(env("FOO= bar")).to eql("FOO" => "bar")
@@ -141,6 +145,10 @@ export OH_NO_NOT_SET')
 
   it "allows # in quoted value" do
     expect(env('foo="bar#baz" # comment')).to eql("foo" => "bar#baz")
+  end
+
+  it "allows # in quoted value with spaces after seperator" do
+    expect(env('foo= "bar#baz" # comment')).to eql("foo" => "bar#baz")
   end
 
   it "ignores comment lines" do


### PR DESCRIPTION
We have in our `.env`-file an entry with `=` as separator followed by a `\s` and a quoted value including `#` in this way:
```
SECRET_PASSWORD              = 'foo#bar234#'
```
Parsing it leads to the unfortunate cutting after the `#`:
```
env("SECRET_PASSWORD              = 'foo#bar234#'")
=> {"SECRET_PASSWORD"=>"'foo"}
```

This fix will let it parse correctly:
```
env("SECRET_PASSWORD              = 'foo#bar234#'")
=> {"SECRET_PASSWORD"=>"foo#bar234#"}
```
