### PR TITLE
Run specs in random order

### DIFF
--- a/spec/dotenv_spec.rb
+++ b/spec/dotenv_spec.rb
@@ -164,7 +164,7 @@ describe Dotenv do
   describe "with an instrumenter" do
     let(:instrumenter) { double("instrumenter", instrument: {}) }
     before { Dotenv.instrumenter = instrumenter }
-    after { Dotenv.instrumenter = nil }
+    after { Dotenv.instrumenter = ActiveSupport::Notifications }
 
     describe "load" do
       it "instruments if the file exists" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 require "dotenv"
 
 RSpec.configure do |config|
+  config.order = :random
+  Kernel.srand config.seed
+
   # Restore the state of ENV after each spec
   config.before { @env_keys = ENV.keys }
   config.after  { ENV.delete_if { |k, _v| !@env_keys.include?(k) } }


### PR DESCRIPTION
I was hoping to contribute some improvements to the test suite if that'd be welcome (in particular an integration test to catch issues like #394) but first I noticed the test suite isn't running with a random order.

This PR proposes switching the config to run specs in random order, and fixes an order-dependent test failure which was present in the test suite. After this fix I was able to run the test suite one hundred times with a random order and saw no failures 🎉.