### PR TITLE
Add a Dotenv::Railtie.overload method.

### DIFF
--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -39,6 +39,13 @@ module Dotenv
       Dotenv.load(*dotenv_files)
     end
 
+    # Public: Reload dotenv
+    #
+    # Same as `load`, but will override existing values in `ENV`
+    def overload
+      Dotenv.overload(*dotenv_files)
+    end
+
     # Internal: `Rails.root` is nil in Rails 4.1 before the application is
     # initialized, so this falls back to the `RAILS_ROOT` environment variable,
     # or the current working directory.


### PR DESCRIPTION
Add a `Dotenv::Railtie.overload` method, which allows to overload environment variables in Rails context.
Resolves #401.