### PR TITLE
Set RAILS_ENV to test when executing the default rake task

### DIFF
--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -1,6 +1,6 @@
 require "dotenv"
 
-# Fix for rspec rake tasks loading in development
+# Fix for rake tasks loading in development
 #
 # Dotenv loads environment variables when the Rails application is initialized.
 # When running `rake`, the Rails application is initialized in development.
@@ -9,8 +9,10 @@ require "dotenv"
 #
 # See https://github.com/bkeepers/dotenv/issues/219
 if defined?(Rake.application)
-  if Rake.application.top_level_tasks.grep(/^(parallel:spec|spec(:|$))/).any?
-    Rails.env = ENV["RAILS_ENV"] ||= "test"
+  task_regular_expression = /^(default$|parallel:spec|spec(:|$))/
+  if Rake.application.top_level_tasks.grep(task_regular_expression).any?
+    environment = Rake.application.options.show_tasks ? "development" : "test"
+    Rails.env = ENV["RAILS_ENV"] ||= environment
   end
 end
 


### PR DESCRIPTION
This is a followup of #241 and brings the `dotenv-rails` environment
assigning hack in line with the [logic rails uses when the
`test_unit/railtie` is loaded][1].

This is a breaking change for all non `test-unit` users, but brings the
behavior of `dotenv-rails` in line across all uses of `rake test`, `rake
rspec`, `rspec` and `rake`.

Before this change `dotenv-rails` loaded different env files when using
a rails application with `rspec` for tests. `rake spec` was covered by
the previous logic and set the RAILS_ENV to test. Only running `rake`
(which invokes rspec by default) wasn't covered and thus loaded first
the development env files and later the test env.

[1]: https://github.com/rails/rails/blob/6-0-stable/railties/lib/rails/test_unit/railtie.rb#L5-L7