### PR TITLE
Fix template (-t) handling of blank lines and comments

### DIFF
--- a/lib/dotenv/template.rb
+++ b/lib/dotenv/template.rb
@@ -9,8 +9,10 @@ module Dotenv
       File.open(@env_file, "r") do |env_file|
         File.open("#{@env_file}.template", "w") do |env_template|
           env_file.each do |line|
-            variable = line.split("=").first
-            env_template.puts "#{variable}=#{variable}"
+            var, value = line.split("=")
+            is_a_comment = var.strip[0].eql?("#")
+            line_transform = value.nil? || is_a_comment ? line : "#{var}=#{var}"
+            env_template.puts line_transform
           end
         end
       end


### PR DESCRIPTION
Template treats every line as a variable declaration. Add conditions to ensure only variable declarations are templated. Blank lines and comments are left as-is.