### PR TITLE
Fix template (-t) handling of export declarations

### DIFF
--- a/lib/dotenv/template.rb
+++ b/lib/dotenv/template.rb
@@ -1,4 +1,5 @@
 module Dotenv
+  EXPORT_COMMAND = "export ".freeze
   # Class for creating a template from a env file
   class EnvTemplate
     def initialize(env_file)
@@ -17,7 +18,7 @@ module Dotenv
 
     def template_line(line)
       var, value = line.split("=")
-      template = var.delete_prefix "export "
+      template = var.gsub(EXPORT_COMMAND, "")
       is_a_comment = var.strip[0].eql?("#")
       value.nil? || is_a_comment ? line : "#{var}=#{template}"
     end

--- a/lib/dotenv/template.rb
+++ b/lib/dotenv/template.rb
@@ -9,13 +9,17 @@ module Dotenv
       File.open(@env_file, "r") do |env_file|
         File.open("#{@env_file}.template", "w") do |env_template|
           env_file.each do |line|
-            var, value = line.split("=")
-            is_a_comment = var.strip[0].eql?("#")
-            line_transform = value.nil? || is_a_comment ? line : "#{var}=#{var}"
-            env_template.puts line_transform
+            env_template.puts template_line(line)
           end
         end
       end
+    end
+
+    def template_line(line)
+      var, value = line.split("=")
+      template = var.delete_prefix "export "
+      is_a_comment = var.strip[0].eql?("#")
+      value.nil? || is_a_comment ? line : "#{var}=#{template}"
     end
   end
 end

--- a/spec/dotenv/cli_spec.rb
+++ b/spec/dotenv/cli_spec.rb
@@ -80,6 +80,15 @@ describe "dotenv binary" do
       expect(@buffer.string).to eq("FOO=FOO\nFOO2=FOO2\n")
     end
 
+    it "templates variables with export prefix" do
+      @input = StringIO.new("export FOO=BAR\nexport FOO2=BAR2")
+      allow(File).to receive(:open).with(@origin_filename, "r").and_yield(@input)
+      allow(File).to receive(:open).with(@template_filename, "w").and_yield(@buffer)
+      cli = Dotenv::CLI.new(["-t", @origin_filename])
+      cli.send(:parse_argv!, cli.argv)
+      expect(@buffer.string).to eq("export FOO=FOO\nexport FOO2=FOO2\n")
+    end
+
     it "ignores blank lines" do
       @input = StringIO.new("\nFOO=BAR\nFOO2=BAR2")
       allow(File).to receive(:open).with(@origin_filename, "r").and_yield(@input)


### PR DESCRIPTION
Fixed `export` commands being repeated in templated values. 

Current: 
 `export FOO=BAR` templated as `export FOO=export FOO`. 

Fix:
 `export FOO=BAR`  templated as `export FOO=FOO`
