### PR TITLE
Allow changing root directory of env files through Dotenv.root_dir

### DIFF
--- a/lib/dotenv.rb
+++ b/lib/dotenv.rb
@@ -5,7 +5,7 @@ require "dotenv/missing_keys"
 # The top level Dotenv module. The entrypoint for the application logic.
 module Dotenv
   class << self
-    attr_accessor :instrumenter
+    attr_accessor :instrumenter, :root_dir
   end
 
   module_function
@@ -61,7 +61,9 @@ module Dotenv
     filenames << ".env" if filenames.empty?
 
     filenames.reduce({}) do |hash, filename|
-      hash.merge!(yield(File.expand_path(filename)) || {})
+      path = root_dir ? File.join(root_dir, filename) : filename
+
+      hash.merge!(yield(File.expand_path(path)) || {})
     end
   end
 

--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -52,7 +52,7 @@ module Dotenv
     # initialized, so this falls back to the `RAILS_ROOT` environment variable,
     # or the current working directory.
     def root
-      Rails.root || Pathname.new(ENV["RAILS_ROOT"] || Dir.pwd)
+      Dotenv.root_dir || Rails.root || Pathname.new(ENV["RAILS_ROOT"] || Dir.pwd)
     end
 
     # Rails uses `#method_missing` to delegate all class methods to the
@@ -65,10 +65,10 @@ module Dotenv
 
     def dotenv_files
       [
-        root.join(".env.#{Rails.env}.local"),
-        (root.join(".env.local") unless Rails.env.test?),
-        root.join(".env.#{Rails.env}"),
-        root.join(".env")
+        File.expand_path(File.join(root, ".env.#{Rails.env}.local")),
+        (File.expand_path(File.join(root, ".env.local")) unless Rails.env.test?),
+        File.expand_path(File.join(root, ".env.#{Rails.env}")),
+        File.expand_path(File.join(root, ".env"))
       ].compact
     end
 

--- a/spec/dotenv/rails_spec.rb
+++ b/spec/dotenv/rails_spec.rb
@@ -53,9 +53,9 @@ describe Dotenv::Railtie do
     it "does not load .env.local in test rails environment" do
       expect(Dotenv::Railtie.instance.send(:dotenv_files)).to eql(
         [
-          Rails.root.join(".env.test.local"),
-          Rails.root.join(".env.test"),
-          Rails.root.join(".env")
+          Rails.root.join(".env.test.local").to_s,
+          Rails.root.join(".env.test").to_s,
+          Rails.root.join(".env").to_s
         ]
       )
     end
@@ -64,10 +64,10 @@ describe Dotenv::Railtie do
       Rails.env = "development"
       expect(Dotenv::Railtie.instance.send(:dotenv_files)).to eql(
         [
-          Rails.root.join(".env.development.local"),
-          Rails.root.join(".env.local"),
-          Rails.root.join(".env.development"),
-          Rails.root.join(".env")
+          Rails.root.join(".env.development.local").to_s,
+          Rails.root.join(".env.local").to_s,
+          Rails.root.join(".env.development").to_s,
+          Rails.root.join(".env").to_s
         ]
       )
     end
@@ -86,6 +86,14 @@ describe Dotenv::Railtie do
         expect(Dotenv::Railtie.root.to_s).to eql("/tmp")
       end
     end
+
+    it "loads files corectly when changing the root_dir" do
+      path = fixture_path(File.join("env", "other.env"))
+      Dotenv.root_dir = fixture_path("env")
+      Dotenv.load('other.env')
+      expect(Spring.watcher.items).to include(path)
+      Dotenv.root_dir = nil
+    end
   end
 
   context "overload" do
@@ -94,9 +102,9 @@ describe Dotenv::Railtie do
     it "does not load .env.local in test rails environment" do
       expect(Dotenv::Railtie.instance.send(:dotenv_files)).to eql(
         [
-          Rails.root.join(".env.test.local"),
-          Rails.root.join(".env.test"),
-          Rails.root.join(".env")
+          Rails.root.join(".env.test.local").to_s,
+          Rails.root.join(".env.test").to_s,
+          Rails.root.join(".env").to_s
         ]
       )
     end
@@ -105,10 +113,10 @@ describe Dotenv::Railtie do
       Rails.env = "development"
       expect(Dotenv::Railtie.instance.send(:dotenv_files)).to eql(
         [
-          Rails.root.join(".env.development.local"),
-          Rails.root.join(".env.local"),
-          Rails.root.join(".env.development"),
-          Rails.root.join(".env")
+          Rails.root.join(".env.development.local").to_s,
+          Rails.root.join(".env.local").to_s,
+          Rails.root.join(".env.development").to_s,
+          Rails.root.join(".env").to_s
         ]
       )
     end

--- a/spec/fixtures/env/other.env
+++ b/spec/fixtures/env/other.env
@@ -1,0 +1,2 @@
+FROM_RAILS_ENV=env/.env.development
+DOTENV=dev


### PR DESCRIPTION
With this change you can have your `.env` files reside in another directory apart from root.

So you, in your `config/application.rb` you can do:
```ruby
Dotenv.root_dir = File.join(File.dirname(__FILE__), '..', 'env')
Dotenv::Railtie.load
```

Instead of:
```ruby
env_path = File.join(File.dirname(__FILE__), '..', 'env', ".env.#{ENV.fetch('RAILS_ENV', 'development')}")
begin
  Spring.watch(env_path)
rescue NameError
  # Not running using spring
end
Dotenv.load(env_path)

```

Reason behind the change: I wanted to have a different directory for my env files, `env`, inside the root directory, so I could have a `.gitignore` entry for those files there, and to do a `git init` in that directory. When I execute `git clean -fdx` the env files will no longer be deleted this way. Small convenience, I know, but while implementing the second ruby snippet above, I noticed there was no option to simply change the root directory, so I though I could contribute it.

Please let me know what you thing, and if you want me to change anything.