### PR TITLE
feat: unescape escaped characters when value is not quoted

### DIFF
--- a/spec/dotenv/parser_spec.rb
+++ b/spec/dotenv/parser_spec.rb
@@ -13,6 +13,10 @@ describe Dotenv::Parser do
     expect(env("FOO= bar")).to eql("FOO" => "bar")
   end
 
+  it "parses unquoted escape characters correctly" do
+    expect(env("FOO=bar\\ bar")).to eql("FOO" => "bar bar")
+  end
+
   it "parses values with spaces around equal sign" do
     expect(env("FOO =bar")).to eql("FOO" => "bar")
     expect(env("FOO= bar")).to eql("FOO" => "bar")


### PR DESCRIPTION
Thank you for this handy gem. We use it regularly.


When using Ruby's shellwords library to escape values, the following env file is created.

```
export FOO=one\ two
```

Quotes cannot be used around those values, otherwise the backslash is considered a literal.

```
# incorrect
$ export FOO="one\ two"
$ echo $FOO
one\ two

# correct
$ export FOO=one\ two
$ echo $FOO
one two
```

This PR updates the code to correctly unescape characters when quotes are not used
 
The parse_value method had to be refactored to keep Rubocop happy.