### PR TITLE
Update supported platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7']
+        ruby: ['2.5', '2.6', '2.7', '3.0']
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/Gemfile
+++ b/Gemfile
@@ -7,17 +7,3 @@ group :guard do
   gem "guard-bundler"
   gem "rb-fsevent"
 end
-
-platforms :rbx do
-  gem "rubysl", "~> 2.0" # if using anything in the ruby standard library
-end
-
-if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.2.2")
-  # Rack 2 requires Ruby version >= 2.2.2
-  gem "rack", ">= 1.6.5", "< 2.0.0"
-end
-
-if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.1.0")
-  # Nokogiri 1.7 requires Ruby version >= 2.1.0.
-  gem "nokogiri", ">= 1.6.8", "< 1.7.0"
-end


### PR DESCRIPTION
Adds Ruby 3 to the build matrix, and removes conditionals for old versions of mri and rbx