### PR TITLE
Update instruction for loading dotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ dotenv is initialized in your Rails app during the `before_configuration` callba
 # config/application.rb
 Bundler.require(*Rails.groups)
 
-Dotenv::Railtie.load
+# Load dotenv only in development or test environment
+if ['development', 'test'].include? ENV['RAILS_ENV']
+  Dotenv::Railtie.load
+end
 
 HOSTNAME = ENV['HOSTNAME']
 ```


### PR DESCRIPTION
Loading dotenv in production raise error for the obvious reason that we install it only for development and test environment. So I think this instruction should be included in the readme file so that we load it only if we are in the desired environments.