### PR TITLE
fix: respect file importance order when overloading

### DIFF
--- a/lib/dotenv.rb
+++ b/lib/dotenv.rb
@@ -29,7 +29,7 @@ module Dotenv
 
   # same as `load`, but will override existing values in `ENV`
   def overload(*filenames)
-    with(*filenames) do |f|
+    with(*filenames.reverse) do |f|
       ignoring_nonexistent_files do
         env = Environment.new(f, false)
         instrument("dotenv.overload", env: env) { env.apply! }
@@ -39,7 +39,7 @@ module Dotenv
 
   # same as `overload`, but raises Errno::ENOENT if any files don't exist
   def overload!(*filenames)
-    with(*filenames) do |f|
+    with(*filenames.reverse) do |f|
       env = Environment.new(f, false)
       instrument("dotenv.overload", env: env) { env.apply! }
     end

--- a/spec/dotenv/rails_spec.rb
+++ b/spec/dotenv/rails_spec.rb
@@ -113,8 +113,8 @@ describe Dotenv::Railtie do
       )
     end
 
-    it "overloads .env.test with .env" do
-      expect(ENV["DOTENV"]).to eql("true")
+    it "overloads .env with .env.test" do
+      expect(ENV["DOTENV"]).to eql("test")
     end
 
     context "when loading a file containing already set variables" do
@@ -125,7 +125,7 @@ describe Dotenv::Railtie do
 
         expect do
           subject
-        end.to(change { ENV["DOTENV"] }.from("predefined").to("true"))
+        end.to(change { ENV["DOTENV"] }.from("predefined").to("test"))
       end
     end
   end

--- a/spec/dotenv_spec.rb
+++ b/spec/dotenv_spec.rb
@@ -54,6 +54,30 @@ describe Dotenv do
     end
   end
 
+  shared_examples "overload" do
+    context "with multiple files" do
+      let(:env_files) { [fixture_path("important.env"), fixture_path("plain.env")] }
+
+      let(:expected) do
+        {
+          "OPTION_A" => "yep",
+          "OPTION_B" => "2",
+          "OPTION_C" => "3",
+          "OPTION_D" => "4",
+          "OPTION_E" => "5",
+          "PLAIN" => "false"
+        }
+      end
+
+      it "respects the file importance order" do
+        subject
+        expected.each do |key, value|
+          expect(ENV[key]).to eq(value)
+        end
+      end
+    end
+  end
+
   describe "load" do
     let(:env_files) { [] }
     subject { Dotenv.load(*env_files) }
@@ -98,6 +122,9 @@ describe Dotenv do
   end
 
   describe "overload" do
+
+    it_behaves_like "overload"
+
     let(:env_files) { [fixture_path("plain.env")] }
     subject { Dotenv.overload(*env_files) }
     it_behaves_like "load"
@@ -131,6 +158,9 @@ describe Dotenv do
   end
 
   describe "overload!" do
+
+    it_behaves_like "overload"
+
     let(:env_files) { [fixture_path("plain.env")] }
     subject { Dotenv.overload!(*env_files) }
     it_behaves_like "load"
@@ -158,6 +188,8 @@ describe Dotenv do
         expect { subject }.to raise_error(Errno::ENOENT)
       end
     end
+
+
   end
 
   describe "with an instrumenter" do

--- a/spec/fixtures/important.env
+++ b/spec/fixtures/important.env
@@ -1,0 +1,3 @@
+PLAIN=false
+OPTION_A=yep
+OPTION_B=2


### PR DESCRIPTION
As thoroughly described in issue https://github.com/bkeepers/dotenv/issues/424, the `overload` option violates what seems to be the official, documented file priority policy. A patch for Rails was offered in PR https://github.com/bkeepers/dotenv/pull/453, while these changes attempt to target the root cause, including updating the behavior of the CLI.

Some notes:

- This is a breaking change. 
- The documentation and some of the tests appear to contradict each other. It is possible that me (and other affected parties) have misunderstood how the `overload` option is meant to function. Hence, an alternative solution is to update the documentation where applicable so that it is less ambiguous.
- Suggestions for changes are very welcome.