### PR TITLE
fix: always respect file importance order

### DIFF
--- a/lib/dotenv.rb
+++ b/lib/dotenv.rb
@@ -29,7 +29,7 @@ module Dotenv
 
   # same as `load`, but will override existing values in `ENV`
   def overload(*filenames)
-    with(*filenames) do |f|
+    with(*filenames.reverse) do |f|
       ignoring_nonexistent_files do
         env = Environment.new(f, false)
         instrument("dotenv.overload", env: env) { env.apply! }
@@ -39,7 +39,7 @@ module Dotenv
 
   # same as `overload`, but raises Errno::ENOENT if any files don't exist
   def overload!(*filenames)
-    with(*filenames) do |f|
+    with(*filenames.reverse) do |f|
       env = Environment.new(f, false)
       instrument("dotenv.overload", env: env) { env.apply! }
     end

--- a/spec/dotenv/rails_spec.rb
+++ b/spec/dotenv/rails_spec.rb
@@ -113,8 +113,8 @@ describe Dotenv::Railtie do
       )
     end
 
-    it "overloads .env.test with .env" do
-      expect(ENV["DOTENV"]).to eql("true")
+    it "overloads .env with .env.test" do
+      expect(ENV["DOTENV"]).to eql("test")
     end
 
     context "when loading a file containing already set variables" do
@@ -125,7 +125,7 @@ describe Dotenv::Railtie do
 
         expect do
           subject
-        end.to(change { ENV["DOTENV"] }.from("predefined").to("true"))
+        end.to(change { ENV["DOTENV"] }.from("predefined").to("test"))
       end
     end
   end

--- a/spec/dotenv_spec.rb
+++ b/spec/dotenv_spec.rb
@@ -54,6 +54,30 @@ describe Dotenv do
     end
   end
 
+  shared_examples "overload" do
+    context "with multiple files" do
+      let(:env_files) { [fixture_path("important.env"), fixture_path("plain.env")] }
+
+      let(:expected) do
+        {
+          "OPTION_A" => "abc",
+          "OPTION_B" => "2",
+          "OPTION_C" => "3",
+          "OPTION_D" => "4",
+          "OPTION_E" => "5",
+          "PLAIN" => "false"
+        }
+      end
+
+      it "respects the file importance order" do
+        subject
+        expected.each do |key, value|
+          expect(ENV[key]).to eq(value)
+        end
+      end
+    end
+  end
+
   describe "load" do
     let(:env_files) { [] }
     subject { Dotenv.load(*env_files) }
@@ -101,6 +125,7 @@ describe Dotenv do
     let(:env_files) { [fixture_path("plain.env")] }
     subject { Dotenv.overload(*env_files) }
     it_behaves_like "load"
+    it_behaves_like "overload"
 
     it "initializes the Environment with a falsey is_load" do
       expect(Dotenv::Environment).to receive(:new).with(anything, false)
@@ -134,6 +159,7 @@ describe Dotenv do
     let(:env_files) { [fixture_path("plain.env")] }
     subject { Dotenv.overload!(*env_files) }
     it_behaves_like "load"
+    it_behaves_like "overload"
 
     it "initializes the Environment with a falsey is_load" do
       expect(Dotenv::Environment).to receive(:new).with(anything, false)

--- a/spec/fixtures/important.env
+++ b/spec/fixtures/important.env
@@ -1,0 +1,3 @@
+PLAIN=false
+OPTION_A=abc
+OPTION_B=2


### PR DESCRIPTION
## Solves the following issue:

### Steps to reproduce

```bash
$ cat Gemfile
# frozen_string_literal: true

source "https://rubygems.org"

ruby File.read("#{File.dirname(__FILE__)}/.ruby-version")

gem "pry"

group :development, :test do
  gem "dotenv"
end
$ cat Gemfile.lock
GEM
  remote: https://rubygems.org/
  specs:
    coderay (1.1.3)
    dotenv (2.8.1)
    method_source (1.0.0)
    pry (0.13.1)
      coderay (~> 1.1)
      method_source (~> 1.0)

PLATFORMS
  ruby

DEPENDENCIES
  dotenv
  pry

RUBY VERSION
   ruby 3.1.2p20

BUNDLED WITH
   2.3.16

$ cat bin/scripts/console
#!/usr/bin/env ruby
# frozen_string_literal: true

require "pry"
Pry.start
$ cat .env.important
EXAMPLE_VAR=5678
$ cat .env.most.important
EXAMPLE_VAR=1234
$ bundle exec dotenv -o -f ".env.most.important,.env.important" ./bin/scripts/console
[1] pry(main)> ENV["EXAMPLE_VAR"]
=> "5678"
[2] pry(main)> exit
$ bundle exec dotenv -o -f ".env.important,.env.most.important" ./bin/scripts/console
[1] pry(main)> ENV["EXAMPLE_VAR"]
=> "1234"
```

### Expected behavior
The environment variables in `.env.most.important` take precedence over those in `.env.important`.
```bash
$ bundle exec dotenv -o -f ".env.most.important,.env.important" ./bin/scripts/console
[1] pry(main)> ENV["EXAMPLE_VAR"]
=> "1234"
````

Quoting from the [README.md](https://github.com/bkeepers/dotenv#readme) file:

> The dotenv executable also accepts a single flag, -f. Its value should be a comma-separated list of configuration files, in the order of most important to least. All of the files must exist. There must be a space between the flag and its value.
> 
> `$ dotenv -f ".env.local,.env" ./script.rb`


### Actual behavior
The environment variables in `.env.most.important` are overloaded by those in `.env.important`, i.e. the file priority policy is violated.
```bash
$ bundle exec dotenv -o -f ".env.most.important,.env.important" ./bin/scripts/console
[1] pry(main)> ENV["EXAMPLE_VAR"]
=> "5678"
````

### System configuration
**dotenv version**: 2.8.1

**Ruby version**: 3.1.2

### Additional info

As thoroughly described in issue https://github.com/bkeepers/dotenv/issues/424, the `overload` option violates what seems to be the official, documented file priority policy. A patch for Rails was offered in PR https://github.com/bkeepers/dotenv/pull/453, while these changes attempt to target the root cause, including updating the behavior of the CLI.

Some notes:

- This is a breaking change. 
- The documentation and some of the tests appear to contradict each other. It is possible that me (and other affected parties) have misunderstood how the `overload` option is meant to function. Hence, an alternative solution is to update the documentation where applicable so that it is less ambiguous. Specifically, it would be good to address how the `-f` and `-o` flags work in tandem.
- Suggestions for changes/other solutions are very welcome.