### PR TITLE
Include Rails integration in `dotenv` gem and refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ But it is not always practical to set environment variables on development machi
 Add this line to the top of your application's Gemfile:
 
 ```ruby
-gem 'dotenv-rails', groups: [:development, :test]
+gem 'dotenv', groups: [:development, :test]
 ```
 
 And then execute:
@@ -24,7 +24,7 @@ $ bundle
 
 #### Note on load order
 
-dotenv is initialized in your Rails app during the `before_configuration` callback, which is fired when the `Application` constant is defined in `config/application.rb` with `class Application < Rails::Application`. If you need it to be initialized sooner, you can manually call `Dotenv::Railtie.load`.
+dotenv is initialized in your Rails app during the `before_configuration` callback, which is fired when the `Application` constant is defined in `config/application.rb` with `class Application < Rails::Application`. If you need it to be initialized sooner, you can manually call `Dotenv::Rails.load`.
 
 ```ruby
 # config/application.rb
@@ -32,16 +32,16 @@ Bundler.require(*Rails.groups)
 
 # Load dotenv only in development or test environment
 if ['development', 'test'].include? ENV['RAILS_ENV']
-  Dotenv::Railtie.load
+  Dotenv::Rails.load
 end
 
 HOSTNAME = ENV['HOSTNAME']
 ```
 
-If you use gems that require environment variables to be set before they are loaded, then list `dotenv-rails` in the `Gemfile` before those other gems and require `dotenv/rails-now`.
+If you use gems that require environment variables to be set before they are loaded, then list `dotenv` in the `Gemfile` before those other gems and require `dotenv/load`.
 
 ```ruby
-gem 'dotenv-rails', require: 'dotenv/rails-now'
+gem 'dotenv', require: 'dotenv/load'
 gem 'gem-that-requires-env-variables'
 ```
 
@@ -94,7 +94,7 @@ To ensure `.env` is loaded in rake, load the tasks:
 require 'dotenv/tasks'
 
 task mytask: :dotenv do
-    # things that require .env
+  # things that require .env
 end
 ```
 

--- a/dotenv-rails.gemspec
+++ b/dotenv-rails.gemspec
@@ -7,9 +7,7 @@ Gem::Specification.new "dotenv-rails", Dotenv::VERSION do |gem|
   gem.description = gem.summary = "Autoload dotenv in Rails."
   gem.homepage = "https://github.com/bkeepers/dotenv"
   gem.license = "MIT"
-  gem.files = `git ls-files lib | grep rails`.split(
-    $OUTPUT_RECORD_SEPARATOR
-  ) + ["README.md", "LICENSE"]
+  gem.files = `git ls-files lib | grep dotenv-rails.rb`.split("\n") + ["README.md", "LICENSE"]
 
   gem.add_dependency "dotenv", Dotenv::VERSION
   gem.add_dependency "railties", ">= 3.2"

--- a/dotenv.gemspec
+++ b/dotenv.gemspec
@@ -8,8 +8,7 @@ Gem::Specification.new "dotenv", Dotenv::VERSION do |gem|
   gem.homepage = "https://github.com/bkeepers/dotenv"
   gem.license = "MIT"
 
-  gem_files = `git ls-files README.md LICENSE lib bin | grep -v rails`
-  gem.files = gem_files.split($OUTPUT_RECORD_SEPARATOR)
+  gem.files = `git ls-files README.md LICENSE lib bin | grep -v dotenv-rails.rb`.split("\n")
   gem.executables = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
 
   gem.add_development_dependency "rake"

--- a/lib/dotenv.rb
+++ b/lib/dotenv.rb
@@ -69,3 +69,5 @@ module Dotenv
     raise MissingKeys, missing_keys
   end
 end
+
+require "dotenv/rails" if defined?(Rails::Railtie)

--- a/lib/dotenv/load.rb
+++ b/lib/dotenv/load.rb
@@ -1,2 +1,3 @@
 require "dotenv"
-Dotenv.load
+
+defined?(Dotenv::Rails) ? Dotenv::Rails.load : Dotenv.load

--- a/lib/dotenv/rails-now.rb
+++ b/lib/dotenv/rails-now.rb
@@ -1,10 +1,10 @@
 # If you use gems that require environment variables to be set before they are
-# loaded, then list `dotenv-rails` in the `Gemfile` before those other gems and
-# require `dotenv/rails-now`.
+# loaded, then list `dotenv` in the `Gemfile` before those other gems and
+# require `dotenv/load`.
 #
-#     gem "dotenv-rails", require: "dotenv/rails-now"
+#     gem "dotenv", require: "dotenv/load"
 #     gem "gem-that-requires-env-variables"
 #
 
-require "dotenv/rails"
-Dotenv::Railtie.load
+require "dotenv/load"
+warn '[DEPRECATION] `require "dotenv/rails-now"` is deprecated. Use `require "dotenv/load"` instead.', caller(1..1).first

--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -29,7 +29,7 @@ module Dotenv
     # Public: Load dotenv
     #
     # This will get called during the `before_configuration` callback, but you
-    # can manually call `Dotenv::Railtie.load` if you needed it sooner.
+    # can manually call `Dotenv::Rails.load` if you needed it sooner.
     def load
       Dotenv.load(*files)
     end
@@ -83,7 +83,7 @@ module Dotenv
 
     config.before_configuration do
       Dotenv.instrumenter = ActiveSupport::Notifications
-      mode == :load ? load : overload
+      (mode == :load) ? load : overload
     end
   end
 

--- a/spec/dotenv/rails_spec.rb
+++ b/spec/dotenv/rails_spec.rb
@@ -8,7 +8,7 @@ describe Dotenv::Rails do
     Dotenv::Rails.remove_instance_variable(:@instance)
 
     Rails.env = "test"
-    allow(Rails).to receive(:root).and_return Pathname.new(__dir__).join('../fixtures')
+    allow(Rails).to receive(:root).and_return Pathname.new(__dir__).join("../fixtures")
     Rails.application = double(:application)
     Spring.watcher = Set.new # Responds to #add
   end

--- a/spec/dotenv/rails_spec.rb
+++ b/spec/dotenv/rails_spec.rb
@@ -4,13 +4,15 @@ require "dotenv/rails"
 
 describe Dotenv::Rails do
   before do
-    # Remove the singleton instance if it exists
-    Dotenv::Rails.remove_instance_variable(:@instance) rescue nil
-
     Rails.env = "test"
     allow(Rails).to receive(:root).and_return Pathname.new(__dir__).join("../fixtures")
     Rails.application = double(:application)
     Spring.watcher = Set.new # Responds to #add
+  end
+
+  after do
+    # Remove the singleton instance if it exists
+    Dotenv::Rails.remove_instance_variable(:@instance)
   end
 
   after do
@@ -53,8 +55,8 @@ describe Dotenv::Rails do
 
   context "before_configuration" do
     it "calls #load" do
-      expect(Dotenv::Rails).to receive(:load)
-      ActiveSupport.run_load_hooks(:before_configuration, )
+      expect(Dotenv::Rails.instance).to receive(:load)
+      ActiveSupport.run_load_hooks(:before_configuration)
     end
   end
 

--- a/spec/dotenv/rails_spec.rb
+++ b/spec/dotenv/rails_spec.rb
@@ -15,10 +15,10 @@ class SpecWatcher
   end
 end
 
-describe Dotenv::Railtie do
+describe Dotenv::Rails do
   before do
     # Remove the singleton instance if it exists
-    Dotenv::Railtie.remove_instance_variable(:@instance)
+    Dotenv::Rails.remove_instance_variable(:@instance)
 
     Rails.env = "test"
     allow(Rails).to receive(:root).and_return Pathname.new(__dir__).join('../fixtures')
@@ -36,7 +36,7 @@ describe Dotenv::Railtie do
     it "loads files for development environment" do
       Rails.env = "development"
 
-      expect(Dotenv::Railtie.config.dotenv.files).to eql(
+      expect(Dotenv::Rails.config.dotenv.files).to eql(
         [
           Rails.root.join(".env.development.local"),
           Rails.root.join(".env.local"),
@@ -48,7 +48,7 @@ describe Dotenv::Railtie do
 
     it "does not load .env.local in test rails environment" do
       Rails.env = "test"
-      expect(Dotenv::Railtie.config.dotenv.files).to eql(
+      expect(Dotenv::Rails.config.dotenv.files).to eql(
         [
           Rails.root.join(".env.test.local"),
           Rails.root.join(".env.test"),
@@ -61,23 +61,23 @@ describe Dotenv::Railtie do
   context "before_configuration" do
     context "with mode = :load" do
       it "calls #load" do
-        expect(Dotenv::Railtie.instance).to receive(:load)
+        expect(Dotenv::Rails.instance).to receive(:load)
         ActiveSupport.run_load_hooks(:before_configuration)
       end
     end
 
     context "with mode = :overload" do
-      before { Dotenv::Railtie.config.dotenv.mode = :overload }
+      before { Dotenv::Rails.config.dotenv.mode = :overload }
 
       it "calls #overload" do
-        expect(Dotenv::Railtie.instance).to receive(:overload)
+        expect(Dotenv::Rails.instance).to receive(:overload)
         ActiveSupport.run_load_hooks(:before_configuration)
       end
     end
   end
 
   context "load" do
-    before { Dotenv::Railtie.load }
+    before { Dotenv::Rails.load }
 
     it "watches .env with Spring" do
       expect(Spring.watcher.items).to include(Rails.root.join(".env").to_s)
@@ -95,8 +95,8 @@ describe Dotenv::Railtie do
 
     it "loads configured files" do
       expect(Dotenv).to receive(:load).with("custom.env")
-      Dotenv::Railtie.config.dotenv.files = ["custom.env"]
-      Dotenv::Railtie.load
+      Dotenv::Rails.config.dotenv.files = ["custom.env"]
+      Dotenv::Rails.load
     end
 
     context "when Rails.root is nil" do
@@ -106,13 +106,13 @@ describe Dotenv::Railtie do
 
       it "falls back to RAILS_ROOT" do
         ENV["RAILS_ROOT"] = "/tmp"
-        expect(Dotenv::Railtie.root.to_s).to eql("/tmp")
+        expect(Dotenv::Rails.root.to_s).to eql("/tmp")
       end
     end
   end
 
   context "overload" do
-    before { Dotenv::Railtie.overload }
+    before { Dotenv::Rails.overload }
 
     it "overloads .env with .env.test" do
       expect(ENV["DOTENV"]).to eql("test")
@@ -120,12 +120,12 @@ describe Dotenv::Railtie do
 
     it "loads configured files" do
       expect(Dotenv).to receive(:overload).with("custom.env")
-      Dotenv::Railtie.config.dotenv.files = ["custom.env"]
-      Dotenv::Railtie.overload
+      Dotenv::Rails.config.dotenv.files = ["custom.env"]
+      Dotenv::Rails.overload
     end
 
     context "when loading a file containing already set variables" do
-      subject { Dotenv::Railtie.overload }
+      subject { Dotenv::Rails.overload }
 
       it "overrides any existing ENV variables" do
         ENV["DOTENV"] = "predefined"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,5 +7,5 @@ RSpec.configure do |config|
 end
 
 def fixture_path(name)
-  File.join(File.expand_path("../fixtures", __FILE__), name)
+  Pathname.new(__dir__).join("./fixtures", name)
 end


### PR DESCRIPTION
This refactors the Rails integration, and includes it in the `dotenv` gem by default.

- Renames `Dotenv::Railtie` => `Dotenv::Rails`
- Adds `Dotenv::Rails.files`, which can be mutated to change which files are loaded
- Adds `Dotenv::Rails.overwrite = true` to overwrite existing ENV variables

I thought about deprecating the `dotenv-rails` gem, but for now I can just keep releasing it as an empty gem with a dependency on `dotenv`. 