### PR TITLE
Consistently use "overwrite" in place of "overload" and "override"

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,11 +248,11 @@ Credentials should only be accessible on the machines that need access to them. 
 
 Personally, I prefer to commit the `.env` file with development-only settings. This makes it easy for other developers to get started on the project without compromising credentials for other environments. If you follow this advice, make sure that all the credentials for your development environment are different from your other deployments and that the development credentials do not have access to any confidential data.
 
-### Why is it not overriding existing `ENV` variables?
+### Why is it not overwriting existing `ENV` variables?
 
-By default, it **won't** overwrite existing environment variables as dotenv assumes the deployment environment has more knowledge about configuration than the application does. To overwrite existing environment variables you can use `Dotenv.overload`.
+By default, it **won't** overwrite existing environment variables as dotenv assumes the deployment environment has more knowledge about configuration than the application does. To overwrite existing environment variables you can use `Dotenv.load files, overwrite: true`.
 
-You can also use the `-o` or `--overload` flag on the dotenv cli to override existing `ENV` variables.
+You can also use the `-o` or `--overwrite` flag on the dotenv cli to overwrite existing `ENV` variables.
 
 ```console
 $ dotenv -o -f ".env.local,.env"

--- a/lib/dotenv.rb
+++ b/lib/dotenv.rb
@@ -22,15 +22,19 @@ module Dotenv
     load(*filenames, ignore: false)
   end
 
-  # same as `#load`, but will override existing values in `ENV`
-  def overload(*filenames)
+  # same as `#load`, but will overwrite existing values in `ENV`
+  def overwrite(*filenames)
     load(*filenames, overwrite: true)
   end
+  alias_method :overload, :overwrite
+  module_function :overload
 
-  # same as `#overload`, but raises Errno::ENOENT if any files don't exist
-  def overload!(*filenames)
+  # same as `#overwrite`, but raises Errno::ENOENT if any files don't exist
+  def overwrite!(*filenames)
     load(*filenames, overwrite: true, ignore: false)
   end
+  alias_method :overload!, :overwrite!
+  module_function :overload!
 
   # Parses the given files, yielding for each file if a block is given.
   #

--- a/lib/dotenv/cli.rb
+++ b/lib/dotenv/cli.rb
@@ -6,13 +6,13 @@ require "optparse"
 module Dotenv
   # The command line interface
   class CLI < OptionParser
-    attr_reader :argv, :filenames, :overload
+    attr_reader :argv, :filenames, :overwrite
 
     def initialize(argv = [])
       @argv = argv.dup
       @filenames = []
       @ignore = false
-      @overload = false
+      @overwrite = false
 
       super("Usage: dotenv [options]")
       separator ""
@@ -25,9 +25,10 @@ module Dotenv
         @ignore = true
       end
 
-      on("-o", "--overload", "override existing ENV variables") do
-        @overload = true
+      on("-o", "--overwrite", "overwrite existing ENV variables") do
+        @overwrite = true
       end
+      on("--overload") { @overwrite = true }
 
       on("-h", "--help", "Display help") do
         puts self
@@ -48,10 +49,7 @@ module Dotenv
     end
 
     def run
-      method = @overload ? "overload" : "load"
-      method = "#{method}!" unless @ignore
-
-      Dotenv.public_send(method, *@filenames)
+      Dotenv.load(*@filenames, overwrite: @overwrite, ignore: @ignore)
     rescue Errno::ENOENT => e
       abort e.message
     else

--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -38,7 +38,7 @@ module Dotenv
 
     def overload
       deprecator.warn("Dotenv::Rails.overload is deprecated. Set `Dotenv::Rails.overwrite = true` and call Dotenv::Rails.load instead.")
-      Dotenv.overload(*files)
+      Dotenv.load(*files, overwrite: true)
     end
 
     # Internal: `Rails.root` is nil in Rails 4.1 before the application is

--- a/spec/dotenv/environment_spec.rb
+++ b/spec/dotenv/environment_spec.rb
@@ -22,7 +22,7 @@ describe Dotenv::Environment do
       expect(ENV["OPTION_A"]).to eq("1")
     end
 
-    it "does not override defined variables" do
+    it "does not overwrite defined variables" do
       ENV["OPTION_A"] = "predefined"
       subject.apply
       expect(ENV["OPTION_A"]).to eq("predefined")
@@ -36,7 +36,7 @@ describe Dotenv::Environment do
         expect(ENV["OPTION_A"]).to eq("1")
       end
 
-      it "overrides defined variables" do
+      it "overwrites defined variables" do
         ENV["OPTION_A"] = "predefined"
         subject.apply
         expect(ENV["OPTION_A"]).to eq("1")

--- a/spec/dotenv/parser_spec.rb
+++ b/spec/dotenv/parser_spec.rb
@@ -74,7 +74,7 @@ describe Dotenv::Parser do
       .to eql("test")
   end
 
-  it "doesn't expand variables from ENV if in local env in overload" do
+  it "doesn't expand variables from ENV if in local env in overwrite" do
     ENV["FOO"] = "test"
     expect(env("FOO=development\nBAR=${FOO}")["BAR"])
       .to eql("test")

--- a/spec/dotenv/rails_spec.rb
+++ b/spec/dotenv/rails_spec.rb
@@ -86,7 +86,7 @@ describe Dotenv::Rails do
         expect(ENV["DOTENV"]).to eql("test")
       end
 
-      it "overrides any existing ENV variables" do
+      it "overwrites any existing ENV variables" do
         ENV["DOTENV"] = "predefined"
         expect { subject }.to(change { ENV["DOTENV"] }.from("predefined").to("test"))
       end

--- a/spec/dotenv_spec.rb
+++ b/spec/dotenv_spec.rb
@@ -53,7 +53,7 @@ describe Dotenv do
     end
   end
 
-  shared_examples "overload" do
+  shared_examples "overwrite" do
     context "with multiple files" do
       let(:env_files) { [fixture_path("important.env"), fixture_path("plain.env")] }
 
@@ -120,11 +120,11 @@ describe Dotenv do
     end
   end
 
-  describe "overload" do
+  describe "overwrite" do
     let(:env_files) { [fixture_path("plain.env")] }
-    subject { Dotenv.overload(*env_files) }
+    subject { Dotenv.overwrite(*env_files) }
     it_behaves_like "load"
-    it_behaves_like "overload"
+    it_behaves_like "overwrite"
 
     it "initializes the Environment overwrite: true" do
       expect(Dotenv::Environment).to receive(:new).with(anything, overwrite: true)
@@ -135,7 +135,7 @@ describe Dotenv do
     context "when loading a file containing already set variables" do
       let(:env_files) { [fixture_path("plain.env")] }
 
-      it "overrides any existing ENV variables" do
+      it "overwrites any existing ENV variables" do
         ENV["OPTION_A"] = "predefined"
 
         subject
@@ -154,11 +154,11 @@ describe Dotenv do
     end
   end
 
-  describe "overload!" do
+  describe "overwrite!" do
     let(:env_files) { [fixture_path("plain.env")] }
-    subject { Dotenv.overload!(*env_files) }
+    subject { Dotenv.overwrite!(*env_files) }
     it_behaves_like "load"
-    it_behaves_like "overload"
+    it_behaves_like "overwrite"
 
     it "initializes the Environment with overwrite: true" do
       expect(Dotenv::Environment).to receive(:new).with(anything, overwrite: true)
@@ -169,7 +169,7 @@ describe Dotenv do
     context "when loading a file containing already set variables" do
       let(:env_files) { [fixture_path("plain.env")] }
 
-      it "overrides any existing ENV variables" do
+      it "overwrites any existing ENV variables" do
         ENV["OPTION_A"] = "predefined"
         subject
         expect(ENV["OPTION_A"]).to eq("1")


### PR DESCRIPTION
Preferred use: `Dotenv.load files, overwrite: true`

`Dotenv.overload` and `Dotenv.overload!` are still around, but not documented.