### PR TITLE
Require Ruby 3.0 and Rails 7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,16 @@ on:
     branches: [master]
   pull_request:
 jobs:
-  build:
+  test:
+    name: Test on Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         ruby: ['3.0', '3.1', '3.2', '3.3']
+        rails: ['6.1.0', '7.0.0', '7.1.0']
+    env:
+      RAILS_VERSION: ${{ matrix.rails }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source "https://rubygems.org"
 gemspec name: "dotenv"
 gemspec name: "dotenv-rails"
 
+gem "railties", "~> #{ENV["RAILS_VERSION"] || "7.1"}"
+
 group :guard do
   gem "guard-rspec"
   gem "guard-bundler"

--- a/dotenv-rails.gemspec
+++ b/dotenv-rails.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new "dotenv-rails", Dotenv::VERSION do |gem|
   gem.files = `git ls-files lib | grep dotenv-rails.rb`.split("\n") + ["README.md", "LICENSE"]
 
   gem.add_dependency "dotenv", Dotenv::VERSION
-  gem.add_dependency "railties", ">= 3.2"
+  gem.add_dependency "railties", ">= 6.1"
 
   gem.add_development_dependency "spring"
 end

--- a/dotenv.gemspec
+++ b/dotenv.gemspec
@@ -14,4 +14,6 @@ Gem::Specification.new "dotenv", Dotenv::VERSION do |gem|
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "standard"
+
+  gem.required_ruby_version = ">= 3.0"
 end

--- a/lib/dotenv/environment.rb
+++ b/lib/dotenv/environment.rb
@@ -2,9 +2,10 @@ module Dotenv
   # This class inherits from Hash and represents the environment into which
   # Dotenv will load key value pairs from a file.
   class Environment < Hash
-    attr_reader :filename
+    attr_reader :filename, :overwrite
 
     def initialize(filename, overwrite: false)
+      super()
       @filename = filename
       @overwrite = overwrite
       load

--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -81,7 +81,7 @@ module Dotenv
     end
 
     initializer "dotenv.deprecator" do |app|
-      app.deprecators[:dotenv] = deprecator
+      app.deprecators[:dotenv] = deprecator if app.respond_to?(:deprecators)
     end
 
     config.before_configuration { load }

--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -19,6 +19,7 @@ module Dotenv
     attr_accessor :overwrite, :files
 
     def initialize
+      super()
       @overwrite = false
       @files = [
         root.join(".env.#{env}.local"),


### PR DESCRIPTION
- Require Ruby `>= 3.0` and Rails `>= 6.1`. Those using EOL versions can lock dotenv to `~> 2.0`
- Add Rails 6.1, 7.0, and 7.1 to build matrix.
