### PR TITLE
Handle thread safety for Dotenv.restore, Add Dotenv.modify

### DIFF
--- a/lib/dotenv/autorestore.rb
+++ b/lib/dotenv/autorestore.rb
@@ -17,7 +17,13 @@ if defined?(ActiveSupport)
       setup { Dotenv.save }
 
       # Restore ENV after each test
-      teardown { Dotenv.restore }
+      teardown do
+        Dotenv.restore
+      rescue ThreadError => e
+        # Restore will fail if running tests in parallel.
+        warn e.message
+        warn "Set `config.dotenv.autorestore = false` in `config/initializers/test.rb`" if defined?(Dotenv::Rails)
+      end
     end
   end
 end

--- a/lib/dotenv/diff.rb
+++ b/lib/dotenv/diff.rb
@@ -1,10 +1,28 @@
 module Dotenv
-  # Compare two hashes and return the differences
+  # A diff between multiple states of ENV.
   class Diff
-    attr_reader :a, :b
+    attr_reader :a
 
-    def initialize(a, b)
+    # Create a new diff. The initial state defaults to a clone of current ENV. If given a block,
+    # the state of ENV will be preserved as the final state for comparison. Otherwise, the current
+    # ENV will be the current state.
+    def initialize(a: current_env, b: nil, &block)
       @a, @b = a, b
+      if block
+        begin
+          block.call self
+        ensure
+          @b = current_env
+        end
+      end
+    end
+
+    def b
+      @b || current_env
+    end
+
+    def current_env
+      ENV.to_h.freeze
     end
 
     # Return a Hash of keys added with their new values
@@ -22,6 +40,15 @@ module Dotenv
       @changed ||= (b.slice(*a.keys).to_a - a.to_a).map do |(k, v)|
         [k, [a[k], v]]
       end.to_h
+    end
+
+    # Returns a Hash of all added, changed, and removed keys and their new values
+    def env
+      @env ||= b.slice(*(added.keys + changed.keys)).merge(removed.transform_values { |v| nil })
+    end
+
+    def any?
+      [added, removed, changed].any?(&:any?)
     end
   end
 end

--- a/lib/dotenv/environment.rb
+++ b/lib/dotenv/environment.rb
@@ -12,21 +12,11 @@ module Dotenv
     end
 
     def load
-      update Parser.call(read, overwrite: @overwrite)
+      update Parser.call(read, overwrite: overwrite)
     end
 
     def read
       File.open(@filename, "rb:bom|utf-8", &:read)
-    end
-
-    def apply
-      each do |k, v|
-        if @overwrite
-          ENV[k] = v
-        else
-          ENV[k] ||= v
-        end
-      end
     end
   end
 end

--- a/lib/dotenv/log_subscriber.rb
+++ b/lib/dotenv/log_subscriber.rb
@@ -9,13 +9,15 @@ module Dotenv
     end
 
     def load(event)
-      diff = event.payload[:diff]
       env = event.payload[:env]
 
-      # Only show the keys that were added or changed
-      changed = env.slice(*(diff.added.keys + diff.changed.keys)).keys.map { |key| color_var(key) }
+      info "Loaded #{color_filename(env.filename)}"
+    end
 
-      info "Set #{changed.to_sentence} from #{color_filename(env.filename)}" if changed.any?
+    def update(event)
+      diff = event.payload[:diff]
+      changed = diff.env.keys.map { |key| color_var(key) }
+      debug "Set #{changed.to_sentence}" if diff.any?
     end
 
     def save(event)

--- a/spec/dotenv/diff_spec.rb
+++ b/spec/dotenv/diff_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Dotenv::Diff do
   let(:before) { {} }
   let(:after) { {} }
-  subject { Dotenv::Diff.new(before, after) }
+  subject { Dotenv::Diff.new(a: before, b: after) }
 
   context "no changes" do
     let(:before) { {"A" => 1} }
@@ -12,6 +12,8 @@ describe Dotenv::Diff do
     it { expect(subject.added).to eq({}) }
     it { expect(subject.removed).to eq({}) }
     it { expect(subject.changed).to eq({}) }
+    it { expect(subject.any?).to eq(false) }
+    it { expect(subject.env).to eq({}) }
   end
 
   context "key added" do
@@ -20,6 +22,8 @@ describe Dotenv::Diff do
     it { expect(subject.added).to eq("A" => 1) }
     it { expect(subject.removed).to eq({}) }
     it { expect(subject.changed).to eq({}) }
+    it { expect(subject.any?).to eq(true) }
+    it { expect(subject.env).to eq("A" => 1) }
   end
 
   context "key removed" do
@@ -28,6 +32,8 @@ describe Dotenv::Diff do
     it { expect(subject.added).to eq({}) }
     it { expect(subject.removed).to eq("A" => 1) }
     it { expect(subject.changed).to eq({}) }
+    it { expect(subject.any?).to eq(true) }
+    it { expect(subject.env).to eq("A" => nil) }
   end
 
   context "key changed" do
@@ -37,5 +43,7 @@ describe Dotenv::Diff do
     it { expect(subject.added).to eq({}) }
     it { expect(subject.removed).to eq({}) }
     it { expect(subject.changed).to eq("A" => [1, 2]) }
+    it { expect(subject.any?).to eq(true) }
+    it { expect(subject.env).to eq("A" => 2) }
   end
 end

--- a/spec/dotenv/environment_spec.rb
+++ b/spec/dotenv/environment_spec.rb
@@ -16,34 +16,6 @@ describe Dotenv::Environment do
     end
   end
 
-  describe "apply" do
-    it "sets variables in ENV" do
-      subject.apply
-      expect(ENV["OPTION_A"]).to eq("1")
-    end
-
-    it "does not overwrite defined variables" do
-      ENV["OPTION_A"] = "predefined"
-      subject.apply
-      expect(ENV["OPTION_A"]).to eq("predefined")
-    end
-
-    context "with overwrite: true" do
-      subject { env("OPTION_A=1\nOPTION_B=2", overwrite: true) }
-
-      it "sets variables in the ENV" do
-        subject.apply
-        expect(ENV["OPTION_A"]).to eq("1")
-      end
-
-      it "overwrites defined variables" do
-        ENV["OPTION_A"] = "predefined"
-        subject.apply
-        expect(ENV["OPTION_A"]).to eq("1")
-      end
-    end
-  end
-
   require "tempfile"
   def env(text, ...)
     file = Tempfile.new("dotenv")

--- a/spec/dotenv/log_subscriber_spec.rb
+++ b/spec/dotenv/log_subscriber_spec.rb
@@ -11,31 +11,35 @@ describe Dotenv::LogSubscriber do
     Dotenv::Rails.logger = Logger.new(logs)
   end
 
-  context "set" do
-    it "logs when a new instance variable is set" do
+  describe "load" do
+    it "logs when a file is loaded" do
       Dotenv.load(fixture_path("plain.env"))
-      expect(logs.string).to match(/Set.*PLAIN.*from.*plain.env/)
+      expect(logs.string).to match(/Loaded.*plain.env/)
+      expect(logs.string).to match(/Set.*PLAIN/)
+    end
+  end
+
+  context "update" do
+    it "logs when a new instance variable is set" do
+      Dotenv.update({"PLAIN" => "true"})
+      expect(logs.string).to match(/Set.*PLAIN/)
     end
 
     it "logs when an instance variable is overwritten" do
       ENV["PLAIN"] = "nope"
-      Dotenv.load(fixture_path("plain.env"), overwrite: true)
-      expect(logs.string).to match(/Set.*PLAIN.*from.*plain.env/)
+      Dotenv.update({"PLAIN" => "true"}, overwrite: true)
+      expect(logs.string).to match(/Set.*PLAIN/)
     end
 
     it "does not log when an instance variable is not overwritten" do
-      # load everything once and clear the logs
-      Dotenv.load(fixture_path("plain.env"))
-      logs.truncate(0)
-
-      # load again
-      Dotenv.load(fixture_path("plain.env"))
-      expect(logs.string).not_to match(/Set.*plain.env/i)
+      ENV["FOO"] = "existing"
+      Dotenv.update({"FOO" => "new"})
+      expect(logs.string).not_to match(/FOO/)
     end
 
     it "does not log when an instance variable is unchanged" do
       ENV["PLAIN"] = "true"
-      Dotenv.load(fixture_path("plain.env"), overwrite: true)
+      Dotenv.update({"PLAIN" => "true"}, overwrite: true)
       expect(logs.string).not_to match(/PLAIN/)
     end
   end


### PR DESCRIPTION
This fixes an issue with #472 when running Rails tests with `parallelize`. Since `ENV` is global state, modifications are not thread safe. This will raise an error if calling `Dotenv.restore` outside of `Thread.main`, and adds `Dotenv.modify` for a threadsafe way to modify `ENV`.

```ruby
Dotenv.modify(MYVAR: "new value") do
  assert_equal "new value", ENV["MYVAR"]
end
```

Note that the block passed to `#modify` is synchronized in a semaphore, so threads calling it will execute serially.

This PR also refactors `Dotenv::Diff` introduced in #473 and uses it to save/restore.