### PR TITLE
Disable autorestore if using climate_control or ice_age

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Dotenv.load('file1.env', 'file2.env')
 
 Since 3.0, dotenv in a Rails app will automatically restore `ENV` after each test. This means you can modify `ENV` in your tests without fear of leaking state to other tests. It works with both `ActiveSupport::TestCase` and `Rspec`.
 
-To disable this behavior, set `config.dotenv.autorestore = false` in `config/application.rb` or `config/environments/test.rb`.
+To disable this behavior, set `config.dotenv.autorestore = false` in `config/application.rb` or `config/environments/test.rb`. It is disabled by default if your app uses [climate_control](https://github.com/thoughtbot/climate_control) or [ice_age](https://github.com/dpep/ice_age_rb).
 
 To use this behavior outside of a Rails app, just `require "dotenv/autorestore"` in your test suite.
 

--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -32,7 +32,7 @@ module Dotenv
           root.join(".env.#{env}"),
           root.join(".env")
         ].compact,
-        autorestore: env.test?
+        autorestore: env.test? && !defined?(ClimateControl) && !defined?(IceAge)
       )
     end
 

--- a/spec/dotenv/rails_spec.rb
+++ b/spec/dotenv/rails_spec.rb
@@ -150,5 +150,17 @@ describe Dotenv::Rails do
       expect(Dotenv::Rails.instance).not_to receive(:require).with("dotenv/autorestore")
       application.initialize!
     end
+
+    it "is not loaded if ClimateControl is defined" do
+      stub_const("ClimateControl", Module.new)
+      expect(Dotenv::Rails.instance).not_to receive(:require).with("dotenv/autorestore")
+      application.initialize!
+    end
+
+    it "is not loaded if IceAge is defined" do
+      stub_const("IceAge", Module.new)
+      expect(Dotenv::Rails.instance).not_to receive(:require).with("dotenv/autorestore")
+      application.initialize!
+    end
   end
 end


### PR DESCRIPTION
This will disable autorestore if `ClimateControl` or `IceAge` constants are defined.

cc #482 