### PR TITLE
Join files to Rails.root at load time

### DIFF
--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -18,7 +18,7 @@ end
 module Dotenv
   # Rails integration for using Dotenv to load ENV variables from a file
   class Rails < ::Rails::Railtie
-    delegate :files, :files=, :overwrite, :overwrite=, :autorestore, :autorestore=, :logger, :logger=, to: "config.dotenv"
+    delegate :files=, :overwrite, :overwrite=, :autorestore, :autorestore=, :logger, :logger=, to: "config.dotenv"
 
     def initialize
       super()
@@ -27,13 +27,18 @@ module Dotenv
         logger: Dotenv::ReplayLogger.new,
         overwrite: false,
         files: [
-          root.join(".env.#{env}.local"),
-          (root.join(".env.local") unless env.test?),
-          root.join(".env.#{env}"),
-          root.join(".env")
+          ".env.#{env}.local",
+          (".env.local" unless env.test?),
+          ".env.#{env}",
+          ".env"
         ].compact,
         autorestore: env.test?
       )
+    end
+
+    # The list of files to load, joined with Rails.root
+    def files
+      config.dotenv.files.map { |file| root.join(file) }
     end
 
     # Public: Load dotenv

--- a/spec/dotenv/rails_spec.rb
+++ b/spec/dotenv/rails_spec.rb
@@ -65,6 +65,17 @@ describe Dotenv::Rails do
         ]
       )
     end
+
+    it "returns the relatives paths to Rails.root" do
+      expect(Dotenv::Rails.files.last).to eql(fixture_path(".env"))
+      allow(Rails).to receive(:root).and_return(Pathname.new("/tmp"))
+      expect(Dotenv::Rails.files.last.to_s).to eql("/tmp/.env")
+    end
+
+    it "returns absolute paths unchanged" do
+      Dotenv::Rails.files = ["/tmp/.env"]
+      expect(Dotenv::Rails.files).to eql([Pathname.new("/tmp/.env")])
+    end
   end
 
   it "watches other loaded files with Spring" do


### PR DESCRIPTION
In v2, files were joined with `Rails.root` during the `before_configuration` callback. #468 refactored the list of files to be configurable, but caused the paths to be joined with `Rails.root` at the time of app initialization (before Rails.root is set).

@mvz can you try this branch out and let me know if it fixes the issue you were running into?

cc https://github.com/bkeepers/dotenv/discussions/476#discussioncomment-8464531