### PR TITLE
Raise if using an unsupported Rails version

### DIFF
--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -1,7 +1,9 @@
 # Since rubygems doesn't support optional dependencies, we have to manually check
-unless Gem::Requirement.new(">= 6.1").satisfied_by?(Gem::Version.new(Rails.version))
-  warn "dotenv 3.0 only supports Rails 6.1 or later. Use dotenv ~> 2.0."
-  return
+begin
+  gem "railties", ">= 6.1"
+rescue LoadError => error
+  warn "dotenv 3.0 only supports Rails 6.1 or later. Use dotenv ~> 2.0 in your Gemfile: `gem 'dotenv', '~> 2.0'."
+  raise error
 end
 
 require "dotenv"


### PR DESCRIPTION
Requested by @Earlopain in https://github.com/bkeepers/dotenv/pull/481#issuecomment-1945621945.

This will raise an error for people using just the `dotenv` gem with an unsupported Rails version. Those using `dotenv-rails` with an old Rails version will properly resolve to dotenv 2.x. The problem is that this will raise an error for those using dotenv in more advance ways (e.g. they could still call `Dotenv.load` manually and that would be completely fine).

I'm not convinced that this is the right thing to do, so I think I'm going to let this sit for now. If anyone has thoughts one way or the other, please share them.