### PR TITLE
Prevent exception on Rails startup

### DIFF
--- a/lib/dotenv/replay_logger.rb
+++ b/lib/dotenv/replay_logger.rb
@@ -5,6 +5,10 @@ module Dotenv
       @logs = []
     end
 
+    def level
+      Logger::Severity::DEBUG
+    end
+
     def method_missing(name, *args, &block)
       @logs.push([name, args, block])
     end


### PR DESCRIPTION
I'm not entirely sure if this is the "right" way to fix this (in fact, I'm pretty sure it's not...)

But I noticed on a project that since the 3.0 release of `dotenv-rails`, the application would fail to start due to the `ReplayLogger` responding to `#level` as if it were a command to log a statement, rather than a query to determine the level the `Logger` is configured for.

You can see the exception here: https://github.com/zinc-collective/convene/actions/runs/7923719579/job/21633994956?pr=2210