### PR TITLE
Use tagged logger already configured on Rails

### DIFF
--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -90,7 +90,8 @@ module Dotenv
 
     initializer "dotenv", after: :initialize_logger do |app|
       # Set up a new logger once Rails has initialized the logger and replay logs
-      new_logger = ActiveSupport::TaggedLogging.new(::Rails.logger).tagged("dotenv")
+      new_logger = ::Rails.logger
+      new_logger = new_logger.tagged("dotenv") if new_logger.respond_to?(:tagged)
       logger.replay new_logger if logger.respond_to?(:replay)
       self.logger = new_logger
     end

--- a/spec/dotenv/rails_spec.rb
+++ b/spec/dotenv/rails_spec.rb
@@ -31,6 +31,7 @@ describe Dotenv::Rails do
   before do
     Rails.env = "test"
     Rails.application = nil
+    Rails.logger = nil
     Spring.watcher = Set.new # Responds to #add
 
     begin

--- a/spec/dotenv/rails_spec.rb
+++ b/spec/dotenv/rails_spec.rb
@@ -99,11 +99,10 @@ describe Dotenv::Rails do
       application.config.logger = ActiveSupport::Logger.new(StringIO.new)
         .tap { |logger| logger.formatter = ::Logger::Formatter.new }
         .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
-      allow(application.config.logger).to receive(:tagged).and_call_original
+
+      expect(application.config.logger).to receive(:tagged).with("dotenv").and_call_original
 
       subject
-
-      expect(application.config.logger).to have_received(:tagged).with("dotenv")
     end
 
     it "watches .env with Spring" do


### PR DESCRIPTION
Fixes #488

- fix: call `tagged` from an existing tagged logger
- fix: correctly uninitialize logger between runs
