### PR TITLE
Refactor ReplayLogger to extend Logger

### DIFF
--- a/lib/dotenv/replay_logger.rb
+++ b/lib/dotenv/replay_logger.rb
@@ -1,20 +1,20 @@
 module Dotenv
   # A logger that can be used before the apps real logger is initialized.
-  class ReplayLogger
+  class ReplayLogger < Logger
     def initialize
+      super(nil) # Doesn't matter what this is, it won't be used.
       @logs = []
     end
 
-    def method_missing(name, *args, &block)
-      @logs.push([name, args, block])
+    # Override the add method to store logs so we can replay them to a real logger later.
+    def add(*args, &block)
+      @logs.push([args, block])
     end
 
-    def respond_to_missing?(name, include_private = false)
-      (include_private ? Logger.instance_methods : Logger.public_instance_methods).include?(name) || super
-    end
-
+    # Replay the store logs to a real logger.
     def replay(logger)
-      @logs.each { |name, args, block| logger.send(name, *args, &block) }
+      @logs.each { |args, block| logger.add(*args, &block) }
+      @logs.clear
     end
   end
 end

--- a/spec/dotenv/rails_spec.rb
+++ b/spec/dotenv/rails_spec.rb
@@ -3,13 +3,13 @@ require "rails"
 require "dotenv/rails"
 
 describe Dotenv::Rails do
-  let(:log_io) { StringIO.new }
+  let(:log_output) { StringIO.new }
   let(:application) do
-    log_io = self.log_io
+    log_output = self.log_output
     Class.new(Rails::Application) do
       config.load_defaults Rails::VERSION::STRING.to_f
       config.eager_load = false
-      config.logger = ActiveSupport::Logger.new(log_io)
+      config.logger = ActiveSupport::Logger.new(log_output)
       config.root = fixture_path
 
       # Remove method fails since app is reloaded for each test
@@ -201,16 +201,14 @@ describe Dotenv::Rails do
   end
 
   describe "logger" do
-    it "defaults to ReplayLogger" do
-      expect(Dotenv::Rails.logger).to be_a(Dotenv::ReplayLogger)
-      application.initialize!
-      expect(Dotenv::Rails.logger).to be_a(ActiveSupport::BroadcastLogger)
-    end
-
     it "replays to Rails.logger" do
+      expect(Dotenv::Rails.logger).to be_a(Dotenv::ReplayLogger)
       Dotenv::Rails.logger.debug("test")
+
       application.initialize!
-      expect(log_io.string).to include("test")
+
+      expect(Dotenv::Rails.logger).not_to be_a(Dotenv::ReplayLogger)
+      expect(log_output.string).to include("test")
     end
   end
 end


### PR DESCRIPTION
Thanks to @zspencer for pointing out in #487 that the current ReplayLogger could cause exceptions in some circumstances. This refactors it to extend `Logger` so it will behave like a real logger.