### PR TITLE
Require version file so VERSION is available

### DIFF
--- a/lib/dotenv.rb
+++ b/lib/dotenv.rb
@@ -1,3 +1,4 @@
+require "dotenv/version"
 require "dotenv/parser"
 require "dotenv/environment"
 require "dotenv/missing_keys"


### PR DESCRIPTION
I've been updating various apps with latest Dotenv and noticed after that running `Dotenv::VERSION` in a console, it would fail. I wasn't sure if it was missed or intentional to leave out requiring the version file so figured I'd contribute this in case. Thanks!