### PR TITLE
Fix template (-t) handling of multi-line variables

### DIFF
--- a/lib/dotenv/template.rb
+++ b/lib/dotenv/template.rb
@@ -10,17 +10,35 @@ module Dotenv
       File.open(@env_file, "r") do |env_file|
         File.open("#{@env_file}.template", "w") do |env_template|
           env_file.each do |line|
-            env_template.puts template_line(line)
+            if is_comment?(line)
+              env_template.puts line
+            elsif (var = var_defined?(line))
+              if line.match(EXPORT_COMMAND)
+                env_template.puts "export #{var}=#{var}"
+              else
+                env_template.puts "#{var}=#{var}"
+              end
+            elsif line_blank?(line)
+              env_template.puts
+            end
           end
         end
       end
     end
 
-    def template_line(line)
-      var, value = line.split("=")
-      template = var.gsub(EXPORT_COMMAND, "")
-      is_a_comment = var.strip[0].eql?("#")
-      (value.nil? || is_a_comment) ? line : "#{var}=#{template}"
+    private
+
+    def is_comment?(line)
+      line.strip.start_with?("#")
+    end
+
+    def var_defined?(line)
+      match = Dotenv::Parser::LINE.match(line)
+      match && match[1]
+    end
+
+    def line_blank?(line)
+      line.strip.length.zero?
     end
   end
 end

--- a/spec/dotenv/cli_spec.rb
+++ b/spec/dotenv/cli_spec.rb
@@ -89,6 +89,20 @@ describe "dotenv binary" do
       expect(@buffer.string).to eq("export FOO=FOO\nexport FOO2=FOO2\n")
     end
 
+    it "templates multi-line variables" do
+      @input = StringIO.new(<<~TEXT)
+        FOO=BAR
+        FOO2="BAR2
+        BAR2"
+      TEXT
+      allow(File).to receive(:open).with(@origin_filename, "r").and_yield(@input)
+      allow(File).to receive(:open).with(@template_filename, "w").and_yield(@buffer)
+      # call the function that writes to the file
+      Dotenv::CLI.new(["-t", @origin_filename])
+      # reading the buffer and checking its content.
+      expect(@buffer.string).to eq("FOO=FOO\nFOO2=FOO2\n")
+    end
+
     it "ignores blank lines" do
       @input = StringIO.new("\nFOO=BAR\nFOO2=BAR2")
       allow(File).to receive(:open).with(@origin_filename, "r").and_yield(@input)


### PR DESCRIPTION
I'm noticing that multi-line variables aren't properly templated. This input:

```
FOO=BAR
FOO2="BAR2
BAR2
BAR2
BAR2"
FOO3=BAR3
```

produces this output:

```
FOO=FOO
FOO2=FOO2
BAR2
BAR2
BAR2"
FOO3=FOO3
```

My expectation is that it would instead produce this output:

```
FOO=FOO
FOO2=FOO2
FOO3=FOO3
```