### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/dotenv

### DIFF
--- a/dotenv.gemspec
+++ b/dotenv.gemspec
@@ -16,4 +16,6 @@ Gem::Specification.new "dotenv", Dotenv::VERSION do |gem|
   gem.add_development_dependency "standard"
 
   gem.required_ruby_version = ">= 3.0"
+
+  gem.metadata["changelog_uri"] = gem.homepage + "/blob/master/Changelog.md"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/dotenv which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/