### PR TITLE
cleanup: Run standard:fix

### DIFF
--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -26,7 +26,7 @@ module Dotenv
     delegate :files, :files=, :overwrite, :overwrite=, :autorestore, :autorestore=, :logger, to: "config.dotenv"
 
     def initialize
-      super()
+      super
       config.dotenv = ActiveSupport::OrderedOptions.new.update(
         # Rails.logger is not available yet, so we'll save log messages and replay them when it is
         logger: Dotenv::ReplayLogger.new,


### PR DESCRIPTION
This PR offers the auto-fix for the a standardrb violation.

This gets us back to green.

Seen when [cf5dcf7](https://github.com/bkeepers/dotenv/commit/cf5dcf7e6e9ba90ad5cbee0a7467271bd6a4f1b5) ran its build.