### PR TITLE
Only use Spring if already loaded

### DIFF
--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -10,8 +10,8 @@ require "dotenv/log_subscriber"
 Dotenv.instrumenter = ActiveSupport::Notifications
 
 # Watch all loaded env files with Spring
-if defined?(Spring)
-  ActiveSupport::Notifications.subscribe("load.dotenv") do |*args|
+ActiveSupport::Notifications.subscribe("load.dotenv") do |*args|
+  if defined?(Spring)
     event = ActiveSupport::Notifications::Event.new(*args)
     Spring.watch event.payload[:env].filename if Rails.application
   end

--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -10,14 +10,11 @@ require "dotenv/log_subscriber"
 Dotenv.instrumenter = ActiveSupport::Notifications
 
 # Watch all loaded env files with Spring
-begin
-  require "spring/commands"
+if defined?(Spring)
   ActiveSupport::Notifications.subscribe("load.dotenv") do |*args|
     event = ActiveSupport::Notifications::Event.new(*args)
     Spring.watch event.payload[:env].filename if Rails.application
   end
-rescue LoadError, ArgumentError
-  # Spring is not available
 end
 
 module Dotenv

--- a/spec/dotenv/rails_spec.rb
+++ b/spec/dotenv/rails_spec.rb
@@ -34,7 +34,6 @@ describe Dotenv::Rails do
     Rails.env = "test"
     Rails.application = nil
     Rails.logger = nil
-    Spring.watcher = Set.new # Responds to #add
 
     begin
       # Remove the singleton instance if it exists
@@ -76,6 +75,7 @@ describe Dotenv::Rails do
   end
 
   it "watches other loaded files with Spring" do
+    stub_spring
     application.initialize!
     path = fixture_path("plain.env")
     Dotenv.load(path)
@@ -93,6 +93,7 @@ describe Dotenv::Rails do
     subject { application.initialize! }
 
     it "watches .env with Spring" do
+      stub_spring
       subject
       expect(Spring.watcher).to include(fixture_path(".env").to_s)
     end
@@ -203,5 +204,15 @@ describe Dotenv::Rails do
       application.initialize!
       expect(Dotenv::Rails.logger).to be(logger)
     end
+  end
+
+  def stub_spring
+    spring = Struct.new("Spring", :watcher) do
+      def watch(path)
+        watcher.add path
+      end
+    end
+
+    stub_const "Spring", spring.new(Set.new)
   end
 end


### PR DESCRIPTION
This makes it possible for the user to selectively use Spring on a command to command basis

Fixes https://github.com/bkeepers/dotenv/issues/510