### PR TITLE
follow-up https://github.com/bkeepers/dotenv/pull/511/

### DIFF
--- a/lib/dotenv/rails.rb
+++ b/lib/dotenv/rails.rb
@@ -11,7 +11,7 @@ Dotenv.instrumenter = ActiveSupport::Notifications
 
 # Watch all loaded env files with Spring
 ActiveSupport::Notifications.subscribe("load.dotenv") do |*args|
-  if defined?(Spring)
+  if defined?(Spring) && Spring.respond_to?(:watch)
     event = ActiveSupport::Notifications::Event.new(*args)
     Spring.watch event.payload[:env].filename if Rails.application
   end

--- a/spec/dotenv/rails_spec.rb
+++ b/spec/dotenv/rails_spec.rb
@@ -75,7 +75,7 @@ describe Dotenv::Rails do
   end
 
   it "watches other loaded files with Spring" do
-    stub_spring
+    stub_spring(load_watcher: true)
     application.initialize!
     path = fixture_path("plain.env")
     Dotenv.load(path)
@@ -101,7 +101,7 @@ describe Dotenv::Rails do
     subject { application.initialize! }
 
     it "watches .env with Spring" do
-      stub_spring
+      stub_spring(load_watcher: true)
       subject
       expect(Spring.watcher).to include(fixture_path(".env").to_s)
     end
@@ -215,15 +215,15 @@ describe Dotenv::Rails do
   end
 
   def stub_spring(load_watcher: true)
-    spring = Module.new
+    spring = Module.new do
+      if load_watcher
+        def self.watcher
+          @watcher ||= Set.new
+        end
 
-    if load_watcher
-      def spring.watcher
-        @watcher ||= Set.new
-      end
-
-      def spring.watch(path)
-        watcher.add path
+        def self.watch(path)
+          watcher.add path
+        end
       end
     end
 


### PR DESCRIPTION
An exception occurs when invoking the rake task via ./bin/rails.

```
bin/rails aborted!
NoMethodError: undefined method `watch' for Spring:Module (NoMethodError)

    Spring.watch event.payload[:env].filename if Rails.application
          ^^^^^^
.bundle/ruby/3.2.0/gems/dotenv-3.1.3/lib/dotenv/rails.rb:16:in `block in <main>'
```

When using `./bin/rails`, 'spring/client' is loaded, but 'spring/watcher', which is unnecessary for the client-side, is not required.

This PR follows up on https://github.com/bkeepers/dotenv/pull/511/ and fixes exception.