### PR TITLE
Optimize parser by removing repeated hash merges

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ gemspec name: "dotenv"
 gemspec name: "dotenv-rails"
 
 gem "railties", "~> #{ENV["RAILS_VERSION"] || "7.1"}"
+gem "benchmark-ips"
+gem "stackprof"
 
 group :guard do
   gem "guard-rspec"

--- a/benchmark/parse_ips.rb
+++ b/benchmark/parse_ips.rb
@@ -1,0 +1,15 @@
+require "bundler/setup"
+require "dotenv"
+require "benchmark/ips"
+require "tempfile"
+
+f = Tempfile.create("benchmark_ips.env")
+1000.times.map { |i| f.puts "VAR_#{i}=#{i}" }
+f.close
+
+Benchmark.ips do |x|
+  x.report("parse, overwrite:false") { Dotenv.parse(f.path, overwrite: false) }
+  x.report("parse, overwrite:true") { Dotenv.parse(f.path, overwrite: true) }
+end
+
+File.unlink(f.path)

--- a/benchmark/parse_profile.rb
+++ b/benchmark/parse_profile.rb
@@ -1,0 +1,23 @@
+require "bundler/setup"
+require "dotenv"
+require "stackprof"
+require "benchmark/ips"
+require "tempfile"
+
+f = Tempfile.create("benchmark_ips.env")
+1000.times.map { |i| f.puts "VAR_#{i}=#{i}" }
+f.close
+
+profile = StackProf.run(mode: :wall, interval: 1_000) do
+  10_000.times do
+    Dotenv.parse(f.path, overwrite: false)
+  end
+end
+
+result = StackProf::Report.new(profile)
+puts
+result.print_text
+puts "\n\n\n"
+result.print_method(/Dotenv.parse/)
+
+File.unlink(f.path)

--- a/lib/dotenv/parser.rb
+++ b/lib/dotenv/parser.rb
@@ -40,7 +40,7 @@ module Dotenv
     def initialize(string, overwrite: false)
       @string = string
       @hash = {}
-      @overwrite = overwrite
+      @variables_to_ignore = overwrite ? nil : ENV.except("DOTENV_LINEBREAK_MODE")
     end
 
     def call
@@ -48,6 +48,8 @@ module Dotenv
       lines = @string.gsub(/\r\n?/, "\n")
       # Process matches
       lines.scan(LINE).each do |key, value|
+        next if @variables_to_ignore&.include?(key)
+
         @hash[key] = parse_value(value || "")
       end
       # Process non-matches
@@ -104,7 +106,7 @@ module Dotenv
     def perform_substitutions(value, maybe_quote)
       if maybe_quote != "'"
         self.class.substitutions.each do |proc|
-          value = proc.call(value, @hash, overwrite: @overwrite)
+          value = proc.call(value, @hash)
         end
       end
       value

--- a/lib/dotenv/substitutions/command.rb
+++ b/lib/dotenv/substitutions/command.rb
@@ -20,7 +20,7 @@ module Dotenv
           )
         /x
 
-        def call(value, _env, overwrite: false)
+        def call(value, _env)
           # Process interpolated shell commands
           value.gsub(INTERPOLATED_SHELL_COMMAND) do |*|
             # Eliminate opening and closing parentheses

--- a/lib/dotenv/substitutions/variable.rb
+++ b/lib/dotenv/substitutions/variable.rb
@@ -18,11 +18,10 @@ module Dotenv
           \}?           # closing brace
         /xi
 
-        def call(value, env, overwrite: false)
-          combined_env = overwrite ? ENV.to_h.merge(env) : env.merge(ENV)
+        def call(value, env)
           value.gsub(VARIABLE) do |variable|
             match = $LAST_MATCH_INFO
-            substitute(match, variable, combined_env)
+            substitute(match, variable, env)
           end
         end
 
@@ -32,7 +31,7 @@ module Dotenv
           if match[1] == "\\"
             variable[1..]
           elsif match[3]
-            env.fetch(match[3], "")
+            env[match[3]] || ENV[match[3]] || ""
           else
             variable
           end


### PR DESCRIPTION
# Changes

Thanks for the helpful gem!

While profiling the startup time for a large Rails app that's manually invoking `Dotenv.load` very early on in the boot process in order to get access to envvars ASAP, I noticed that the subsequent `Dotenv.load` being automatically called by this gem's provided railtie was taking an unusual amount of time to complete. The time was mostly being spent in the variable substitution module, on this line:

```ruby
combined_env = overwrite ? ENV.to_h.merge(env) : env.merge(ENV)
```

Since `ENV` had already been loaded up with ~2,000 extra variables from the first run of dotenv, this hash merge is not a trivially cheap operation and it added up being run when parsing each line. 

From what I understand, the purpose of that line is to build a lookup table that gives priority to either envvars already in `ENV` or envvars from an earlier line in the file, depending on the value of the "overwrite" flag. We can make this operation unnecessary by updating the parser to simply skip over lines re-defining a variable already in `ENV` when "overwrite = false", leaving the variable substitution module not even having to worry about the prioritization.  

This leads to a modest performance improvement when parsing a large .env file, and a significant one when parsing a large .env file when `ENV` is already very populated by some other process (most likely a previous run of  dotenv, but I can imagine there are other, less avoidable reasons this could happen as well):

![image](https://github.com/user-attachments/assets/2391166d-5e7a-4674-955a-33c3df037644)

![image](https://github.com/user-attachments/assets/0b6d9842-eccf-4a77-a53a-f790ed2306c1)

The .env file used for this benchmark was created from this script:

```ruby
require "securerandom"

lines = Array.new(2000) { "#{SecureRandom.uuid.tr("-", "")}=\"#{SecureRandom.uuid.tr("-", "")}\""}
IO.write("./tmp/.env", lines.join("\n"))
```

# Validation

The RSpec test suite for this gem looks to be pretty thorough and it's all still passing after this change, so from that I don't believe that this will have any unintended changes in functionality. 