### PR TITLE
Restore previous parser behavior of returning existing variables

### DIFF
--- a/lib/dotenv/parser.rb
+++ b/lib/dotenv/parser.rb
@@ -52,11 +52,11 @@ module Dotenv
       @string.scan(LINE) do
         match = $LAST_MATCH_INFO
 
-        # Skip parsing values that will be ignored
-        next if ignore?(match[:key])
-
-        # Check for exported variable with no value
-        if match[:export] && !match[:value]
+        if existing?(match[:key])
+          # Use value from already defined variable
+          @hash[match[:key]] = ENV[match[:key]]
+        elsif match[:export] && !match[:value]
+          # Check for exported variable with no value
           if !@hash.member?(match[:key])
             raise FormatError, "Line #{match.to_s.inspect} has an unset variable"
           end
@@ -70,8 +70,8 @@ module Dotenv
 
     private
 
-    # Determine if the key can be ignored.
-    def ignore?(key)
+    # Determine if a variable is already defined and should not be overwritten.
+    def existing?(key)
       !@overwrite && key != "DOTENV_LINEBREAK_MODE" && ENV.key?(key)
     end
 

--- a/spec/dotenv/parser_spec.rb
+++ b/spec/dotenv/parser_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 
 describe Dotenv::Parser do
-  def env(string)
-    Dotenv::Parser.call(string)
+  def env(...)
+    Dotenv::Parser.call(...)
   end
 
   it "parses unquoted values" do
@@ -297,5 +297,10 @@ one more line")
           .to eql("VAR1 is var1")
       end
     end
+  end
+
+  it "returns existing value for redefined variable" do
+    ENV["FOO"] = "existing"
+    expect(env("FOO=bar")).to eql("FOO" => "existing")
   end
 end


### PR DESCRIPTION
Part of the optimization in #515 was to skip parsing variables that were already defined. But that had the side-effect of not returning them in the resulting hash. This adds a test for this behavior and restores it.

Fixes #518 