### PR TITLE
Add latest Rails and Ruby versions to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.0', '3.1', '3.2', '3.3']
-        rails: ['6.1.0', '7.0.0', '7.1.0']
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
+        rails: ["6.1.0", "7.0.0", "7.1.0", "7.2.0", "8.0.0"]
     env:
       RAILS_VERSION: ${{ matrix.rails }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4", head]
-        rails: ["6.1.0", "7.0.0", "7.1.0", "7.2.0", "8.0.0"]
+        ruby: ["3.1", "3.2", "3.3", "3.4", head]
+        rails: ["7.0.0", "7.1.0", "7.2.0", "8.0.0"]
     env:
       RAILS_VERSION: ${{ matrix.rails }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,25 @@ on:
     branches: [main]
   pull_request:
 jobs:
-  test:
-    name: Test on Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}
+  versions:
+    name: Get latest versions
     runs-on: ubuntu-latest
+    outputs:
+      ruby: ${{ steps.ruby.outputs.latest }}
+    steps:
+      - id: ruby
+        run: |
+          DATA=$(curl https://endoflife.date/api/ruby.json)
+          SUPPORTED=$(echo $DATA | jq '[.[] | select(.eol > (now | strftime("%Y-%m-%d")))]')
+          echo "latest=$(echo $SUPPORTED | jq -c 'map(.latest)')" >> $GITHUB_OUTPUT
+  test:
+    needs: versions
+    runs-on: ubuntu-latest
+    name: Test on Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4", head]
+        ruby: ${{ fromJSON(needs.versions.outputs.ruby) }}
         rails: ["7.0.0", "7.1.0", "7.2.0", "8.0.0"]
     env:
       RAILS_VERSION: ${{ matrix.rails }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4", head]
         rails: ["6.1.0", "7.0.0", "7.1.0", "7.2.0", "8.0.0"]
     env:
       RAILS_VERSION: ${{ matrix.rails }}


### PR DESCRIPTION
Adds Rails 7.2 and 8, along with the upcoming Ruby 3.4 and `head`.