### PR TITLE
Generate build matrix from endoflife.date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,15 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Set up Ruby
+        id: setup-ruby
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
           ruby-version: ${{ matrix.ruby }}
+        continue-on-error: true
+      - name: Incompatible Versions
+        if: steps.setup-ruby.outcome == 'failure'
+        run: echo "Ruby ${{ matrix.ruby }} is not supported with Rails ${{ matrix.rails }}"
       - name: Run Rake
+        if: steps.setup-ruby.outcome != 'failure'
         run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,31 @@ on:
     branches: [main]
   pull_request:
 jobs:
-  test:
-    name: Test on Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}
+  versions:
+    name: Get latest versions
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        product: ["ruby", "rails"]
+    outputs:
+      ruby: ${{ steps.supported.outputs.ruby }}
+      rails: ${{ steps.supported.outputs.rails }}
+    steps:
+      - id: supported
+        run: |
+          product="${{ matrix.product }}"
+          data=$(curl https://endoflife.date/api/$product.json)
+          supported=$(echo $data | jq '[.[] | select(.eol > (now | strftime("%Y-%m-%d")))]')
+          echo "${product}=$(echo $supported | jq -c 'map(.latest)')" >> $GITHUB_OUTPUT
+  test:
+    needs: versions
+    runs-on: ubuntu-latest
+    name: Test on Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.0', '3.1', '3.2', '3.3']
-        rails: ['6.1.0', '7.0.0', '7.1.0']
+        ruby: ${{ fromJSON(needs.versions.outputs.ruby) }}
+        rails: ${{ fromJSON(needs.versions.outputs.rails) }}
     env:
       RAILS_VERSION: ${{ matrix.rails }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches: [main]
   pull_request:
+  schedule:
+    - cron: "0 0 * * *" # Once/day
+
 jobs:
   versions:
     name: Get latest versions


### PR DESCRIPTION
I get tired of having to manually update Ruby/Rails versions in the GitHub Actions config, so this is an experiment to automate it by fetching the currently supported versions from endoflife.date.

- [x] Get all non-EOL versions from endoflife.date
- [x] Skip incompatible combinations (e.g Rails 8 requires doesn't support Ruby 3.1)