### PR TITLE
Fix issue with repeated linebreaks when normalizing line endings

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,12 @@
 
 [Unreleased changes](https://github.com/bkeepers/dotenv/compare/v3.1.6...main)
 
+## 3.1.7
+
+* Fix issue with repeated linebreaks when normalizing line endings by @bkeepers in https://github.com/bkeepers/dotenv/pull/523
+
+**Full Changelog**: https://github.com/bkeepers/dotenv/compare/v3.1.6...v3.1.7
+
 ## 3.1.6
 
 * Fix: Restore previous parser behavior of returning existing variables by @bkeepers in https://github.com/bkeepers/dotenv/pull/519

--- a/lib/dotenv/parser.rb
+++ b/lib/dotenv/parser.rb
@@ -43,7 +43,7 @@ module Dotenv
 
     def initialize(string, overwrite: false)
       # Convert line breaks to same format
-      @string = string.gsub(/[\n\r]+/, "\n")
+      @string = string.gsub(/\r\n?/, "\n")
       @hash = {}
       @overwrite = overwrite
     end

--- a/lib/dotenv/version.rb
+++ b/lib/dotenv/version.rb
@@ -1,3 +1,3 @@
 module Dotenv
-  VERSION = "3.1.6".freeze
+  VERSION = "3.1.7".freeze
 end

--- a/spec/dotenv/parser_spec.rb
+++ b/spec/dotenv/parser_spec.rb
@@ -158,6 +158,11 @@ export OH_NO_NOT_SET')
       .to eql("foo" => "bar", "fizz" => "buzz")
   end
 
+  it "does not ignore empty lines in quoted string" do
+    value = "a\n\nb\n\nc"
+    expect(env("FOO=\"#{value}\"")).to eql("FOO" => value)
+  end
+
   it "ignores inline comments" do
     expect(env("foo=bar # this is foo")).to eql("foo" => "bar")
   end


### PR DESCRIPTION
#517 had an over-eager regex that removes repeated linebreaks when normalizing line endings. This adds a tests for that scenario and fixes #522.