### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/dotenv-rails

### DIFF
--- a/dotenv-rails.gemspec
+++ b/dotenv-rails.gemspec
@@ -13,4 +13,6 @@ Gem::Specification.new "dotenv-rails", Dotenv::VERSION do |gem|
   gem.add_dependency "railties", ">= 6.1"
 
   gem.add_development_dependency "spring"
+
+  gem.metadata["changelog_uri"] = "https://github.com/bkeepers/dotenv/releases"
 end


### PR DESCRIPTION
A changelog_uri value was added to the dotenv.gemspec in [PR#506](https://github.com/bkeepers/dotenv/pull/506). This PR adds it to dotenv-rails.gemspec as well so that the 'Changelog' link will be shown on https://rubygems.org/gems/dotenv-rails