### PR TITLE
Handle parentheses in variables in commands

### DIFF
--- a/lib/dotenv/substitutions/command.rb
+++ b/lib/dotenv/substitutions/command.rb
@@ -20,7 +20,7 @@ module Dotenv
           )
         /x
 
-        def call(value, _env)
+        def call(value, &block)
           # Process interpolated shell commands
           value.gsub(INTERPOLATED_SHELL_COMMAND) do |*|
             # Eliminate opening and closing parentheses
@@ -31,7 +31,7 @@ module Dotenv
               $LAST_MATCH_INFO[0][1..]
             else
               # Execute the command and return the value
-              `#{command}`.chomp
+              `#{block.call command}`.chomp
             end
           end
         end

--- a/spec/dotenv/parser_spec.rb
+++ b/spec/dotenv/parser_spec.rb
@@ -273,6 +273,10 @@ one more line")
         .to eql("Quotes won't be a problem")
     end
 
+    it "handles parentheses in variables in commands" do
+      expect(env("FOO='passwo(rd'\nBAR=$(echo '$FOO')")).to eql("FOO" => "passwo(rd", "BAR" => "passwo(rd")
+    end
+
     it "supports carriage return" do
       expect(env("FOO=bar\rbaz=fbb")).to eql("FOO" => "bar", "baz" => "fbb")
     end


### PR DESCRIPTION
Variables with parentheses are not handled correctly in commands:

```
FOO='passwo(rd'
BAR=$(echo '$FOO')
```

Result:

```
expected: {"BAR"=>"passwo(rd",           "FOO"=>"passwo(rd"}
     got: {"BAR"=>"$(echo 'passwo(rd')", "FOO"=>"passwo(rd"}
```

The solution I suggest is to parse commands first and expand variables before executing commands.