### PR TITLE
Handle parentheses in variables in commands

### DIFF
--- a/lib/dotenv/parser.rb
+++ b/lib/dotenv/parser.rb
@@ -9,8 +9,8 @@ module Dotenv
   # It allows for variable substitutions, command substitutions, and exporting of variables.
   class Parser
     @substitutions = [
-      Dotenv::Substitutions::Variable,
-      Dotenv::Substitutions::Command
+      Dotenv::Substitutions::Command,
+      Dotenv::Substitutions::Variable
     ]
 
     LINE = /

--- a/lib/dotenv/substitutions/command.rb
+++ b/lib/dotenv/substitutions/command.rb
@@ -20,7 +20,7 @@ module Dotenv
           )
         /x
 
-        def call(value, _env)
+        def call(value, env)
           # Process interpolated shell commands
           value.gsub(INTERPOLATED_SHELL_COMMAND) do |*|
             # Eliminate opening and closing parentheses
@@ -31,7 +31,7 @@ module Dotenv
               $LAST_MATCH_INFO[0][1..]
             else
               # Execute the command and return the value
-              `#{command}`.chomp
+              `#{Variable.call(command, env)}`.chomp
             end
           end
         end

--- a/spec/dotenv/parser_spec.rb
+++ b/spec/dotenv/parser_spec.rb
@@ -273,6 +273,10 @@ one more line")
         .to eql("Quotes won't be a problem")
     end
 
+    it "handles parentheses in variables in commands" do
+      expect(env("FOO='passwo(rd'\nBAR=$(echo '$FOO')")).to eql("FOO" => "passwo(rd", "BAR" => "passwo(rd")
+    end
+
     it "supports carriage return" do
       expect(env("FOO=bar\rbaz=fbb")).to eql("FOO" => "bar", "baz" => "fbb")
     end


### PR DESCRIPTION
Variables with parentheses are not handled correctly in commands:

```
FOO='passwo(rd'
BAR=$(echo '$FOO')
```

Result:

```
expected: {"BAR"=>"passwo(rd",           "FOO"=>"passwo(rd"}
     got: {"BAR"=>"$(echo 'passwo(rd')", "FOO"=>"passwo(rd"}
```

The solution I suggest is to parse commands first and expand variables before executing commands.

**Dependencies**

This change will break kamal which is included in Rails by default. This is how I want to handle it:
* Get an approval for the `dotenv` patch but not merge it.
* Deliver backward compatible patch to `kamal` https://github.com/basecamp/kamal/pull/1346
* Merge this PR once the patched version of `kamal` is released.